### PR TITLE
add netezza dir

### DIFF
--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -55,6 +55,10 @@ if(ADBC_DRIVER_POSTGRESQL)
   add_subdirectory(driver/postgresql)
 endif()
 
+if(ADBC_DRIVER_NETEZZA)
+  add_subdirectory(driver/netezza)
+endif()
+
 if(ADBC_DRIVER_SQLITE)
   add_subdirectory(driver/sqlite)
 endif()

--- a/c/CMakePresets.json
+++ b/c/CMakePresets.json
@@ -17,6 +17,7 @@
                 "ADBC_DRIVER_FLIGHTSQL": "ON",
                 "ADBC_DRIVER_MANAGER": "ON",
                 "ADBC_DRIVER_POSTGRESQL": "ON",
+                "ADBC_DRIVER_NETEZZA": "ON",
                 "ADBC_DRIVER_SNOWFLAKE": "ON",
                 "ADBC_DRIVER_SQLITE": "ON",
                 "ADBC_USE_ASAN": "ON",

--- a/c/cmake_modules/DefineOptions.cmake
+++ b/c/cmake_modules/DefineOptions.cmake
@@ -234,6 +234,7 @@ if("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}")
   define_option(ADBC_DRIVER_FLIGHTSQL "Build the Flight SQL driver" OFF)
   define_option(ADBC_DRIVER_MANAGER "Build the driver manager" OFF)
   define_option(ADBC_DRIVER_POSTGRESQL "Build the PostgreSQL driver" OFF)
+  define_option(ADBC_DRIVER_NETEZZA "Build the IBM Netezza driver" OFF)
   define_option(ADBC_DRIVER_SQLITE "Build the SQLite driver" OFF)
   define_option(ADBC_DRIVER_SNOWFLAKE "Build the Snowflake driver" OFF)
 

--- a/c/driver/netezza/AdbcDriverPostgreSQLConfig.cmake.in
+++ b/c/driver/netezza/AdbcDriverPostgreSQLConfig.cmake.in
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+@PACKAGE_INIT@
+
+set(ADBC_VERSION "@ADBC_VERSION@")
+
+include("${CMAKE_CURRENT_LIST_DIR}/AdbcDriverPostgreSQLTargets.cmake")
+
+check_required_components(AdbcDriverPostgreSQL)

--- a/c/driver/netezza/CMakeLists.txt
+++ b/c/driver/netezza/CMakeLists.txt
@@ -1,0 +1,111 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+if(WIN32)
+  # XXX: for now, assume vcpkg
+  find_package(PostgreSQL REQUIRED)
+  set(LIBPQ_LINK_LIBRARIES PostgreSQL::PostgreSQL wsock32 ws2_32)
+  set(LIBPQ_STATIC_LIBRARIES PostgreSQL::PostgreSQL)
+  set(LIBPQ_INCLUDE_DIRS)
+else()
+  find_package(PkgConfig)
+  pkg_check_modules(LIBPQ REQUIRED libpq)
+endif()
+
+add_arrow_lib(adbc_driver_postgresql
+              SOURCES
+              connection.cc
+              error.cc
+              database.cc
+              postgresql.cc
+              result_helper.cc
+              statement.cc
+              OUTPUTS
+              ADBC_LIBRARIES
+              CMAKE_PACKAGE_NAME
+              AdbcDriverPostgreSQL
+              PKG_CONFIG_NAME
+              adbc-driver-postgresql
+              SHARED_LINK_FLAGS
+              ${ADBC_LINK_FLAGS}
+              SHARED_LINK_LIBS
+              adbc_driver_common
+              nanoarrow
+              ${LIBPQ_LINK_LIBRARIES}
+              STATIC_LINK_LIBS
+              ${LIBPQ_LINK_LIBRARIES}
+              adbc_driver_common
+              nanoarrow
+              ${LIBPQ_STATIC_LIBRARIES})
+
+foreach(LIB_TARGET ${ADBC_LIBRARIES})
+  target_compile_definitions(${LIB_TARGET} PRIVATE ADBC_EXPORTING)
+  target_include_directories(${LIB_TARGET} SYSTEM
+                             PRIVATE ${REPOSITORY_ROOT}
+                                     ${REPOSITORY_ROOT}/c/
+                                     ${LIBPQ_INCLUDE_DIRS}
+                                     ${REPOSITORY_ROOT}/c/vendor
+                                     ${REPOSITORY_ROOT}/c/driver)
+endforeach()
+
+if(ADBC_TEST_LINKAGE STREQUAL "shared")
+  set(TEST_LINK_LIBS adbc_driver_postgresql_shared)
+else()
+  set(TEST_LINK_LIBS adbc_driver_postgresql_static)
+endif()
+
+if(ADBC_BUILD_TESTS)
+  add_test_case(driver_postgresql_test
+                PREFIX
+                adbc
+                EXTRA_LABELS
+                driver-postgresql
+                SOURCES
+                postgres_type_test.cc
+                postgres_copy_reader_test.cc
+                postgresql_test.cc
+                EXTRA_LINK_LIBS
+                adbc_driver_common
+                adbc_validation
+                nanoarrow
+                ${TEST_LINK_LIBS})
+  target_compile_features(adbc-driver-postgresql-test PRIVATE cxx_std_17)
+  target_include_directories(adbc-driver-postgresql-test SYSTEM
+                             PRIVATE ${REPOSITORY_ROOT}
+                                     ${REPOSITORY_ROOT}/c/
+                                     ${LIBPQ_INCLUDE_DIRS}
+                                     ${REPOSITORY_ROOT}/c/vendor
+                                     ${REPOSITORY_ROOT}/c/driver)
+  adbc_configure_target(adbc-driver-postgresql-test)
+endif()
+
+if(ADBC_BUILD_BENCHMARKS)
+  find_package(benchmark REQUIRED)
+  # TODO: should add_benchmark be linking benchmark::benchmark for us?
+  add_benchmark(postgresql_benchmark
+                EXTRA_LINK_LIBS
+                adbc_driver_common
+                adbc_validation
+                nanoarrow
+                ${TEST_LINK_LIBS}
+                benchmark::benchmark)
+  # add_benchmark replaces _ with - when creating target
+  target_include_directories(postgresql-benchmark
+                             PRIVATE ${REPOSITORY_ROOT} ${REPOSITORY_ROOT}/c/
+                                     ${REPOSITORY_ROOT}/c/vendor
+                                     ${REPOSITORY_ROOT}/c/driver)
+endif()

--- a/c/driver/netezza/CMakeUserPresets.example.json
+++ b/c/driver/netezza/CMakeUserPresets.example.json
@@ -1,0 +1,33 @@
+{
+    "version": 3,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 21,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "user-local",
+            "displayName": "(user) local build",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "ADBC_BUILD_TESTS": "ON"
+            },
+            "environment": {
+                "PKG_CONFIG_PATH": ""
+            }
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "user-test-preset",
+            "description": "",
+            "displayName": "(user) test preset",
+            "configurePreset": "user-local",
+            "environment": {
+              "CTEST_OUTPUT_ON_FAILURE": "1",
+              "ADBC_POSTGRESQL_TEST_URI": "postgresql://localhost:5432/postgres?user=postgres&password=password"
+            }
+        }
+    ]
+}

--- a/c/driver/netezza/README.md
+++ b/c/driver/netezza/README.md
@@ -1,0 +1,72 @@
+<!---
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+# ADBC PostgreSQL Driver
+
+This implements an ADBC driver that wraps [libpq][libpq], the client
+library for PostgreSQL.  This is still a work in progress.
+
+This project owes credit to 0x0L's [pgeon][pgeon] for the overall
+approach.
+
+**NOTE:** this project is not affiliated with PostgreSQL in any way.
+
+[libpq]: https://www.postgresql.org/docs/current/libpq.html
+[pgeon]: https://github.com/0x0L/pgeon
+
+## Building
+
+Dependencies: libpq itself. This can be installed with your favorite
+package manager; however, you may need to set the `PKG_CONFIG_PATH`
+environment variable such that `pkg-config` can find libpq.
+
+See [CONTRIBUTING.md](../../CONTRIBUTING.md) for details.
+
+## Testing
+
+A running instance of PostgreSQL is required.  For example, using Docker:
+
+```shell
+$ docker run -it --rm \
+    -e POSTGRES_PASSWORD=password \
+    -e POSTGRES_DB=tempdb \
+    -p 5432:5432 \
+    postgres
+```
+
+Alternatively use the `docker compose` provided by ADBC to manage the test
+database container.
+
+```shell
+$ docker compose up postgres-test
+# When finished:
+# docker compose down postgres-test
+```
+
+Then, to run the tests, set the environment variable specifying the
+PostgreSQL URI before running tests:
+
+```shell
+$ export ADBC_POSTGRESQL_TEST_URI=postgresql://localhost:5432/postgres?user=postgres&password=password
+$ ctest
+```
+
+Users of VSCode can use the CMake extension with the supplied CMakeUserPresets.json
+example to supply the required CMake and environment variables required to build and
+run tests.

--- a/c/driver/netezza/adbc-driver-postgresql.pc.in
+++ b/c/driver/netezza/adbc-driver-postgresql.pc.in
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+prefix=@CMAKE_INSTALL_PREFIX@
+includedir=@ADBC_PKG_CONFIG_INCLUDEDIR@
+libdir=@ADBC_PKG_CONFIG_LIBDIR@
+
+Name: Apache Arrow Database Connectivity (ADBC) PostgreSQL driver
+Description: The ADBC PostgreSQL driver provides an ADBC driver for PostgreSQL.
+Version: @ADBC_VERSION@
+Libs: -L${libdir} -ladbc_driver_postgresql
+Cflags: -I${includedir}

--- a/c/driver/netezza/connection.cc
+++ b/c/driver/netezza/connection.cc
@@ -1,0 +1,1365 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "connection.h"
+
+#include <cassert>
+#include <cinttypes>
+#include <cmath>
+#include <cstring>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <adbc.h>
+#include <libpq-fe.h>
+
+#include "common/utils.h"
+#include "database.h"
+#include "error.h"
+#include "result_helper.h"
+
+namespace adbcpq {
+namespace {
+
+static const uint32_t kSupportedInfoCodes[] = {
+    ADBC_INFO_VENDOR_NAME,          ADBC_INFO_VENDOR_VERSION,
+    ADBC_INFO_DRIVER_NAME,          ADBC_INFO_DRIVER_VERSION,
+    ADBC_INFO_DRIVER_ARROW_VERSION, ADBC_INFO_DRIVER_ADBC_VERSION,
+};
+
+static const std::unordered_map<std::string, std::string> kPgTableTypes = {
+    {"table", "r"},       {"view", "v"},          {"materialized_view", "m"},
+    {"toast_table", "t"}, {"foreign_table", "f"}, {"partitioned_table", "p"}};
+
+class PqGetObjectsHelper {
+ public:
+  PqGetObjectsHelper(PGconn* conn, int depth, const char* catalog, const char* db_schema,
+                     const char* table_name, const char** table_types,
+                     const char* column_name, struct ArrowSchema* schema,
+                     struct ArrowArray* array, struct AdbcError* error)
+      : conn_(conn),
+        depth_(depth),
+        catalog_(catalog),
+        db_schema_(db_schema),
+        table_name_(table_name),
+        table_types_(table_types),
+        column_name_(column_name),
+        schema_(schema),
+        array_(array),
+        error_(error) {
+    na_error_ = {0};
+  }
+
+  AdbcStatusCode GetObjects() {
+    RAISE_ADBC(InitArrowArray());
+
+    catalog_name_col_ = array_->children[0];
+    catalog_db_schemas_col_ = array_->children[1];
+    catalog_db_schemas_items_ = catalog_db_schemas_col_->children[0];
+    db_schema_name_col_ = catalog_db_schemas_items_->children[0];
+    db_schema_tables_col_ = catalog_db_schemas_items_->children[1];
+    schema_table_items_ = db_schema_tables_col_->children[0];
+    table_name_col_ = schema_table_items_->children[0];
+    table_type_col_ = schema_table_items_->children[1];
+
+    table_columns_col_ = schema_table_items_->children[2];
+    table_columns_items_ = table_columns_col_->children[0];
+    column_name_col_ = table_columns_items_->children[0];
+    column_position_col_ = table_columns_items_->children[1];
+    column_remarks_col_ = table_columns_items_->children[2];
+
+    table_constraints_col_ = schema_table_items_->children[3];
+    table_constraints_items_ = table_constraints_col_->children[0];
+    constraint_name_col_ = table_constraints_items_->children[0];
+    constraint_type_col_ = table_constraints_items_->children[1];
+
+    constraint_column_names_col_ = table_constraints_items_->children[2];
+    constraint_column_name_col_ = constraint_column_names_col_->children[0];
+
+    constraint_column_usages_col_ = table_constraints_items_->children[3];
+    constraint_column_usage_items_ = constraint_column_usages_col_->children[0];
+    fk_catalog_col_ = constraint_column_usage_items_->children[0];
+    fk_db_schema_col_ = constraint_column_usage_items_->children[1];
+    fk_table_col_ = constraint_column_usage_items_->children[2];
+    fk_column_name_col_ = constraint_column_usage_items_->children[3];
+
+    RAISE_ADBC(AppendCatalogs());
+    RAISE_ADBC(FinishArrowArray());
+    return ADBC_STATUS_OK;
+  }
+
+ private:
+  AdbcStatusCode InitArrowArray() {
+    RAISE_ADBC(AdbcInitConnectionObjectsSchema(schema_, error_));
+
+    CHECK_NA_DETAIL(INTERNAL, ArrowArrayInitFromSchema(array_, schema_, &na_error_),
+                    &na_error_, error_);
+
+    CHECK_NA(INTERNAL, ArrowArrayStartAppending(array_), error_);
+    return ADBC_STATUS_OK;
+  }
+
+  AdbcStatusCode AppendSchemas(std::string db_name) {
+    // postgres only allows you to list schemas for the currently connected db
+    if (!strcmp(db_name.c_str(), PQdb(conn_))) {
+      struct StringBuilder query;
+      std::memset(&query, 0, sizeof(query));
+      if (StringBuilderInit(&query, /*initial_size*/ 256)) {
+        return ADBC_STATUS_INTERNAL;
+      }
+
+      const char* stmt =
+          "SELECT nspname FROM pg_catalog.pg_namespace WHERE "
+          "nspname !~ '^pg_' AND nspname <> 'information_schema'";
+
+      if (StringBuilderAppend(&query, "%s", stmt)) {
+        StringBuilderReset(&query);
+        return ADBC_STATUS_INTERNAL;
+      }
+
+      std::vector<std::string> params;
+      if (db_schema_ != NULL) {
+        if (StringBuilderAppend(&query, "%s", " AND nspname = $1")) {
+          StringBuilderReset(&query);
+          return ADBC_STATUS_INTERNAL;
+        }
+        params.push_back(db_schema_);
+      }
+
+      auto result_helper =
+          PqResultHelper{conn_, std::string(query.buffer), params, error_};
+      StringBuilderReset(&query);
+
+      RAISE_ADBC(result_helper.Prepare());
+      RAISE_ADBC(result_helper.Execute());
+
+      for (PqResultRow row : result_helper) {
+        const char* schema_name = row[0].data;
+        CHECK_NA(INTERNAL,
+                 ArrowArrayAppendString(db_schema_name_col_, ArrowCharView(schema_name)),
+                 error_);
+        if (depth_ == ADBC_OBJECT_DEPTH_DB_SCHEMAS) {
+          CHECK_NA(INTERNAL, ArrowArrayAppendNull(db_schema_tables_col_, 1), error_);
+        } else {
+          RAISE_ADBC(AppendTables(std::string(schema_name)));
+        }
+        CHECK_NA(INTERNAL, ArrowArrayFinishElement(catalog_db_schemas_items_), error_);
+      }
+    }
+
+    CHECK_NA(INTERNAL, ArrowArrayFinishElement(catalog_db_schemas_col_), error_);
+    return ADBC_STATUS_OK;
+  }
+
+  AdbcStatusCode AppendCatalogs() {
+    struct StringBuilder query;
+    std::memset(&query, 0, sizeof(query));
+    if (StringBuilderInit(&query, /*initial_size=*/256) != 0) return ADBC_STATUS_INTERNAL;
+
+    if (StringBuilderAppend(&query, "%s", "SELECT datname FROM pg_catalog.pg_database")) {
+      return ADBC_STATUS_INTERNAL;
+    }
+
+    std::vector<std::string> params;
+    if (catalog_ != NULL) {
+      if (StringBuilderAppend(&query, "%s", " WHERE datname = $1")) {
+        StringBuilderReset(&query);
+        return ADBC_STATUS_INTERNAL;
+      }
+      params.push_back(catalog_);
+    }
+
+    PqResultHelper result_helper =
+        PqResultHelper{conn_, std::string(query.buffer), params, error_};
+    StringBuilderReset(&query);
+
+    RAISE_ADBC(result_helper.Prepare());
+    RAISE_ADBC(result_helper.Execute());
+
+    for (PqResultRow row : result_helper) {
+      const char* db_name = row[0].data;
+      CHECK_NA(INTERNAL,
+               ArrowArrayAppendString(catalog_name_col_, ArrowCharView(db_name)), error_);
+      if (depth_ == ADBC_OBJECT_DEPTH_CATALOGS) {
+        CHECK_NA(INTERNAL, ArrowArrayAppendNull(catalog_db_schemas_col_, 1), error_);
+      } else {
+        RAISE_ADBC(AppendSchemas(std::string(db_name)));
+      }
+      CHECK_NA(INTERNAL, ArrowArrayFinishElement(array_), error_);
+    }
+
+    return ADBC_STATUS_OK;
+  }
+
+  AdbcStatusCode AppendTables(std::string schema_name) {
+    struct StringBuilder query;
+    std::memset(&query, 0, sizeof(query));
+    if (StringBuilderInit(&query, /*initial_size*/ 512)) {
+      return ADBC_STATUS_INTERNAL;
+    }
+
+    std::vector<std::string> params = {schema_name};
+    const char* stmt =
+        "SELECT c.relname, CASE c.relkind WHEN 'r' THEN 'table' WHEN 'v' THEN 'view' "
+        "WHEN 'm' THEN 'materialized view' WHEN 't' THEN 'TOAST table' "
+        "WHEN 'f' THEN 'foreign table' WHEN 'p' THEN 'partitioned table' END "
+        "AS reltype FROM pg_catalog.pg_class c "
+        "LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace "
+        "WHERE c.relkind IN ('r','v','m','t','f','p') "
+        "AND pg_catalog.pg_table_is_visible(c.oid) AND n.nspname = $1";
+
+    if (StringBuilderAppend(&query, "%s", stmt)) {
+      StringBuilderReset(&query);
+      return ADBC_STATUS_INTERNAL;
+    }
+
+    if (table_name_ != nullptr) {
+      if (StringBuilderAppend(&query, "%s", " AND c.relname LIKE $2")) {
+        StringBuilderReset(&query);
+        return ADBC_STATUS_INTERNAL;
+      }
+
+      params.push_back(std::string(table_name_));
+    }
+
+    if (table_types_ != nullptr) {
+      std::vector<std::string> table_type_filter;
+      const char** table_types = table_types_;
+      while (*table_types != NULL) {
+        auto table_type_str = std::string(*table_types);
+        auto search = kPgTableTypes.find(table_type_str);
+        if (search != kPgTableTypes.end()) {
+          table_type_filter.push_back(search->second);
+        }
+        table_types++;
+      }
+
+      if (!table_type_filter.empty()) {
+        std::ostringstream oss;
+        bool first = true;
+        oss << "(";
+        for (const auto& str : table_type_filter) {
+          if (!first) {
+            oss << ", ";
+          }
+          oss << "'" << str << "'";
+          first = false;
+        }
+        oss << ")";
+
+        if (StringBuilderAppend(&query, "%s%s", " AND c.relkind IN ",
+                                oss.str().c_str())) {
+          StringBuilderReset(&query);
+          return ADBC_STATUS_INTERNAL;
+        }
+      } else {
+        // no matching table type means no records should come back
+        if (StringBuilderAppend(&query, "%s", " AND false")) {
+          StringBuilderReset(&query);
+          return ADBC_STATUS_INTERNAL;
+        }
+      }
+    }
+
+    auto result_helper = PqResultHelper{conn_, query.buffer, params, error_};
+    StringBuilderReset(&query);
+
+    RAISE_ADBC(result_helper.Prepare());
+    RAISE_ADBC(result_helper.Execute());
+    for (PqResultRow row : result_helper) {
+      const char* table_name = row[0].data;
+      const char* table_type = row[1].data;
+
+      CHECK_NA(INTERNAL,
+               ArrowArrayAppendString(table_name_col_, ArrowCharView(table_name)),
+               error_);
+      CHECK_NA(INTERNAL,
+               ArrowArrayAppendString(table_type_col_, ArrowCharView(table_type)),
+               error_);
+      if (depth_ == ADBC_OBJECT_DEPTH_TABLES) {
+        CHECK_NA(INTERNAL, ArrowArrayAppendNull(table_columns_col_, 1), error_);
+        CHECK_NA(INTERNAL, ArrowArrayAppendNull(table_constraints_col_, 1), error_);
+      } else {
+        auto table_name_s = std::string(table_name);
+        RAISE_ADBC(AppendColumns(schema_name, table_name_s));
+        RAISE_ADBC(AppendConstraints(schema_name, table_name_s));
+      }
+      CHECK_NA(INTERNAL, ArrowArrayFinishElement(schema_table_items_), error_);
+    }
+
+    CHECK_NA(INTERNAL, ArrowArrayFinishElement(db_schema_tables_col_), error_);
+    return ADBC_STATUS_OK;
+  }
+
+  AdbcStatusCode AppendColumns(std::string schema_name, std::string table_name) {
+    struct StringBuilder query;
+    std::memset(&query, 0, sizeof(query));
+    if (StringBuilderInit(&query, /*initial_size*/ 512)) {
+      return ADBC_STATUS_INTERNAL;
+    }
+
+    std::vector<std::string> params = {schema_name, table_name};
+    const char* stmt =
+        "SELECT attr.attname, attr.attnum, "
+        "pg_catalog.col_description(cls.oid, attr.attnum) "
+        "FROM pg_catalog.pg_attribute AS attr "
+        "INNER JOIN pg_catalog.pg_class AS cls ON attr.attrelid = cls.oid "
+        "INNER JOIN pg_catalog.pg_namespace AS nsp ON nsp.oid = cls.relnamespace "
+        "WHERE attr.attnum > 0 AND NOT attr.attisdropped "
+        "AND nsp.nspname LIKE $1 AND cls.relname LIKE $2";
+
+    if (StringBuilderAppend(&query, "%s", stmt)) {
+      StringBuilderReset(&query);
+      return ADBC_STATUS_INTERNAL;
+    }
+
+    if (column_name_ != NULL) {
+      if (StringBuilderAppend(&query, "%s", " AND attr.attname LIKE $3")) {
+        StringBuilderReset(&query);
+        return ADBC_STATUS_INTERNAL;
+      }
+
+      params.push_back(std::string(column_name_));
+    }
+
+    auto result_helper = PqResultHelper{conn_, query.buffer, params, error_};
+    StringBuilderReset(&query);
+
+    RAISE_ADBC(result_helper.Prepare());
+    RAISE_ADBC(result_helper.Execute());
+
+    for (PqResultRow row : result_helper) {
+      const char* column_name = row[0].data;
+      const char* position = row[1].data;
+
+      CHECK_NA(INTERNAL,
+               ArrowArrayAppendString(column_name_col_, ArrowCharView(column_name)),
+               error_);
+      int ival = atol(position);
+      CHECK_NA(INTERNAL,
+               ArrowArrayAppendInt(column_position_col_, static_cast<int64_t>(ival)),
+               error_);
+      if (row[2].is_null) {
+        CHECK_NA(INTERNAL, ArrowArrayAppendNull(column_remarks_col_, 1), error_);
+      } else {
+        const char* remarks = row[2].data;
+        CHECK_NA(INTERNAL,
+                 ArrowArrayAppendString(column_remarks_col_, ArrowCharView(remarks)),
+                 error_);
+      }
+
+      // no xdbc_ values for now
+      for (auto i = 3; i < 19; i++) {
+        CHECK_NA(INTERNAL, ArrowArrayAppendNull(table_columns_items_->children[i], 1),
+                 error_);
+      }
+
+      CHECK_NA(INTERNAL, ArrowArrayFinishElement(table_columns_items_), error_);
+    }
+
+    CHECK_NA(INTERNAL, ArrowArrayFinishElement(table_columns_col_), error_);
+    return ADBC_STATUS_OK;
+  }
+
+  // libpq PQexecParams can use either text or binary transfers
+  // For now we are using text transfer internally, so arrays are sent
+  // back like {element1, element2} within a const char*
+  std::vector<std::string> PqTextArrayToVector(std::string text_array) {
+    text_array.erase(0, 1);
+    text_array.erase(text_array.size() - 1);
+
+    std::vector<std::string> elements;
+    std::stringstream ss(std::move(text_array));
+    std::string tmp;
+
+    while (getline(ss, tmp, ',')) {
+      elements.push_back(std::move(tmp));
+    }
+
+    return elements;
+  }
+
+  AdbcStatusCode AppendConstraints(std::string schema_name, std::string table_name) {
+    struct StringBuilder query;
+    std::memset(&query, 0, sizeof(query));
+    if (StringBuilderInit(&query, /*initial_size*/ 4096)) {
+      return ADBC_STATUS_INTERNAL;
+    }
+
+    std::vector<std::string> params = {schema_name, table_name};
+    const char* stmt =
+        "WITH fk_unnest AS ( "
+        "    SELECT "
+        "        con.conname, "
+        "        'FOREIGN KEY' AS contype, "
+        "        conrelid, "
+        "        UNNEST(con.conkey) AS conkey, "
+        "        confrelid, "
+        "        UNNEST(con.confkey) AS confkey "
+        "    FROM pg_catalog.pg_constraint AS con "
+        "    INNER JOIN pg_catalog.pg_class AS cls ON cls.oid = conrelid "
+        "    INNER JOIN pg_catalog.pg_namespace AS nsp ON nsp.oid = cls.relnamespace "
+        "    WHERE con.contype = 'f' AND nsp.nspname LIKE $1 "
+        "    AND cls.relname LIKE $2 "
+        "), "
+        "fk_names AS ( "
+        "    SELECT "
+        "        fk_unnest.conname, "
+        "        fk_unnest.contype, "
+        "        fk_unnest.conkey, "
+        "        fk_unnest.confkey, "
+        "        attr.attname, "
+        "        fnsp.nspname AS fschema, "
+        "        fcls.relname AS ftable, "
+        "        fattr.attname AS fattname "
+        "    FROM fk_unnest "
+        "    INNER JOIN pg_catalog.pg_class AS cls ON cls.oid = fk_unnest.conrelid "
+        "    INNER JOIN pg_catalog.pg_class AS fcls ON fcls.oid = fk_unnest.confrelid "
+        "    INNER JOIN pg_catalog.pg_namespace AS fnsp ON fnsp.oid = fcls.relnamespace"
+        "    INNER JOIN pg_catalog.pg_attribute AS attr ON attr.attnum = "
+        "fk_unnest.conkey "
+        "        AND attr.attrelid = fk_unnest.conrelid "
+        "    LEFT JOIN pg_catalog.pg_attribute AS fattr ON fattr.attnum =  "
+        "fk_unnest.confkey "
+        "        AND fattr.attrelid = fk_unnest.confrelid "
+        "), "
+        "fkeys AS ( "
+        "    SELECT "
+        "        conname, "
+        "        contype, "
+        "        ARRAY_AGG(attname ORDER BY conkey) AS colnames, "
+        "        fschema, "
+        "        ftable, "
+        "        ARRAY_AGG(fattname ORDER BY confkey) AS fcolnames "
+        "    FROM fk_names "
+        "    GROUP BY "
+        "        conname, "
+        "        contype, "
+        "        fschema, "
+        "        ftable "
+        "), "
+        "other_constraints AS ( "
+        "    SELECT con.conname, CASE con.contype WHEN 'c' THEN 'CHECK' WHEN 'u' THEN  "
+        "    'UNIQUE' WHEN 'p' THEN 'PRIMARY KEY' END AS contype, "
+        "    ARRAY_AGG(attr.attname) AS colnames "
+        "    FROM pg_catalog.pg_constraint AS con  "
+        "    CROSS JOIN UNNEST(conkey) AS conkeys  "
+        "    INNER JOIN pg_catalog.pg_class AS cls ON cls.oid = con.conrelid  "
+        "    INNER JOIN pg_catalog.pg_namespace AS nsp ON nsp.oid = cls.relnamespace  "
+        "    INNER JOIN pg_catalog.pg_attribute AS attr ON attr.attnum = conkeys  "
+        "    AND cls.oid = attr.attrelid  "
+        "    WHERE con.contype IN ('c', 'u', 'p') AND nsp.nspname LIKE $1 "
+        "    AND cls.relname LIKE $2 "
+        "    GROUP BY conname, contype "
+        ") "
+        "SELECT "
+        "    conname, contype, colnames, fschema, ftable, fcolnames "
+        "FROM fkeys "
+        "UNION ALL "
+        "SELECT "
+        "    conname, contype, colnames, NULL, NULL, NULL "
+        "FROM other_constraints";
+
+    if (StringBuilderAppend(&query, "%s", stmt)) {
+      StringBuilderReset(&query);
+      return ADBC_STATUS_INTERNAL;
+    }
+
+    if (column_name_ != NULL) {
+      if (StringBuilderAppend(&query, "%s", " WHERE conname LIKE $3")) {
+        StringBuilderReset(&query);
+        return ADBC_STATUS_INTERNAL;
+      }
+
+      params.push_back(std::string(column_name_));
+    }
+
+    auto result_helper = PqResultHelper{conn_, query.buffer, params, error_};
+    StringBuilderReset(&query);
+
+    RAISE_ADBC(result_helper.Prepare());
+    RAISE_ADBC(result_helper.Execute());
+
+    for (PqResultRow row : result_helper) {
+      const char* constraint_name = row[0].data;
+      const char* constraint_type = row[1].data;
+
+      CHECK_NA(
+          INTERNAL,
+          ArrowArrayAppendString(constraint_name_col_, ArrowCharView(constraint_name)),
+          error_);
+
+      CHECK_NA(
+          INTERNAL,
+          ArrowArrayAppendString(constraint_type_col_, ArrowCharView(constraint_type)),
+          error_);
+
+      auto constraint_column_names = PqTextArrayToVector(std::string(row[2].data));
+      for (const auto& constraint_column_name : constraint_column_names) {
+        CHECK_NA(INTERNAL,
+                 ArrowArrayAppendString(constraint_column_name_col_,
+                                        ArrowCharView(constraint_column_name.c_str())),
+                 error_);
+      }
+      CHECK_NA(INTERNAL, ArrowArrayFinishElement(constraint_column_names_col_), error_);
+
+      if (!strcmp(constraint_type, "FOREIGN KEY")) {
+        assert(!row[3].is_null);
+        assert(!row[4].is_null);
+        assert(!row[5].is_null);
+
+        const char* constraint_ftable_schema = row[3].data;
+        const char* constraint_ftable_name = row[4].data;
+        auto constraint_fcolumn_names = PqTextArrayToVector(std::string(row[5].data));
+        for (const auto& constraint_fcolumn_name : constraint_fcolumn_names) {
+          CHECK_NA(INTERNAL,
+                   ArrowArrayAppendString(fk_catalog_col_, ArrowCharView(PQdb(conn_))),
+                   error_);
+          CHECK_NA(INTERNAL,
+                   ArrowArrayAppendString(fk_db_schema_col_,
+                                          ArrowCharView(constraint_ftable_schema)),
+                   error_);
+          CHECK_NA(INTERNAL,
+                   ArrowArrayAppendString(fk_table_col_,
+                                          ArrowCharView(constraint_ftable_name)),
+                   error_);
+          CHECK_NA(INTERNAL,
+                   ArrowArrayAppendString(fk_column_name_col_,
+                                          ArrowCharView(constraint_fcolumn_name.c_str())),
+                   error_);
+
+          CHECK_NA(INTERNAL, ArrowArrayFinishElement(constraint_column_usage_items_),
+                   error_);
+        }
+      }
+      CHECK_NA(INTERNAL, ArrowArrayFinishElement(constraint_column_usages_col_), error_);
+      CHECK_NA(INTERNAL, ArrowArrayFinishElement(table_constraints_items_), error_);
+    }
+
+    CHECK_NA(INTERNAL, ArrowArrayFinishElement(table_constraints_col_), error_);
+    return ADBC_STATUS_OK;
+  }
+
+  AdbcStatusCode FinishArrowArray() {
+    CHECK_NA_DETAIL(INTERNAL, ArrowArrayFinishBuildingDefault(array_, &na_error_),
+                    &na_error_, error_);
+
+    return ADBC_STATUS_OK;
+  }
+
+  PGconn* conn_;
+  int depth_;
+  const char* catalog_;
+  const char* db_schema_;
+  const char* table_name_;
+  const char** table_types_;
+  const char* column_name_;
+  struct ArrowSchema* schema_;
+  struct ArrowArray* array_;
+  struct AdbcError* error_;
+  struct ArrowError na_error_;
+  struct ArrowArray* catalog_name_col_;
+  struct ArrowArray* catalog_db_schemas_col_;
+  struct ArrowArray* catalog_db_schemas_items_;
+  struct ArrowArray* db_schema_name_col_;
+  struct ArrowArray* db_schema_tables_col_;
+  struct ArrowArray* schema_table_items_;
+  struct ArrowArray* table_name_col_;
+  struct ArrowArray* table_type_col_;
+  struct ArrowArray* table_columns_col_;
+  struct ArrowArray* table_columns_items_;
+  struct ArrowArray* column_name_col_;
+  struct ArrowArray* column_position_col_;
+  struct ArrowArray* column_remarks_col_;
+  struct ArrowArray* table_constraints_col_;
+  struct ArrowArray* table_constraints_items_;
+  struct ArrowArray* constraint_name_col_;
+  struct ArrowArray* constraint_type_col_;
+  struct ArrowArray* constraint_column_names_col_;
+  struct ArrowArray* constraint_column_name_col_;
+  struct ArrowArray* constraint_column_usages_col_;
+  struct ArrowArray* constraint_column_usage_items_;
+  struct ArrowArray* fk_catalog_col_;
+  struct ArrowArray* fk_db_schema_col_;
+  struct ArrowArray* fk_table_col_;
+  struct ArrowArray* fk_column_name_col_;
+};
+
+// A notice processor that does nothing with notices. In the future we can log
+// these, but this suppresses the default of printing to stderr.
+void SilentNoticeProcessor(void* /*arg*/, const char* /*message*/) {}
+
+}  // namespace
+
+AdbcStatusCode PostgresConnection::Cancel(struct AdbcError* error) {
+  // > errbuf must be a char array of size errbufsize (the recommended size is
+  // > 256 bytes).
+  // https://www.postgresql.org/docs/current/libpq-cancel.html
+  char errbuf[256];
+  // > The return value is 1 if the cancel request was successfully dispatched
+  // > and 0 if not.
+  if (PQcancel(cancel_, errbuf, sizeof(errbuf)) != 1) {
+    SetError(error, "[libpq] Failed to cancel operation: %s", errbuf);
+    return ADBC_STATUS_UNKNOWN;
+  }
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresConnection::Commit(struct AdbcError* error) {
+  if (autocommit_) {
+    SetError(error, "%s", "[libpq] Cannot commit when autocommit is enabled");
+    return ADBC_STATUS_INVALID_STATE;
+  }
+
+  PGresult* result = PQexec(conn_, "COMMIT; BEGIN TRANSACTION");
+  if (PQresultStatus(result) != PGRES_COMMAND_OK) {
+    AdbcStatusCode code = SetError(error, result, "%s%s",
+                                   "[libpq] Failed to commit: ", PQerrorMessage(conn_));
+    PQclear(result);
+    return code;
+  }
+  PQclear(result);
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresConnection::PostgresConnectionGetInfoImpl(
+    const uint32_t* info_codes, size_t info_codes_length, struct ArrowSchema* schema,
+    struct ArrowArray* array, struct AdbcError* error) {
+  RAISE_ADBC(AdbcInitConnectionGetInfoSchema(info_codes, info_codes_length, schema, array,
+                                             error));
+
+  for (size_t i = 0; i < info_codes_length; i++) {
+    switch (info_codes[i]) {
+      case ADBC_INFO_VENDOR_NAME:
+        RAISE_ADBC(
+            AdbcConnectionGetInfoAppendString(array, info_codes[i], "PostgreSQL", error));
+        break;
+      case ADBC_INFO_VENDOR_VERSION: {
+        const char* stmt = "SHOW server_version_num";
+        auto result_helper = PqResultHelper{conn_, std::string(stmt), error};
+        RAISE_ADBC(result_helper.Prepare());
+        RAISE_ADBC(result_helper.Execute());
+        auto it = result_helper.begin();
+        if (it == result_helper.end()) {
+          SetError(error, "[libpq] PostgreSQL returned no rows for '%s'", stmt);
+          return ADBC_STATUS_INTERNAL;
+        }
+        const char* server_version_num = (*it)[0].data;
+
+        RAISE_ADBC(AdbcConnectionGetInfoAppendString(array, info_codes[i],
+                                                     server_version_num, error));
+        break;
+      }
+      case ADBC_INFO_DRIVER_NAME:
+        RAISE_ADBC(AdbcConnectionGetInfoAppendString(array, info_codes[i],
+                                                     "ADBC PostgreSQL Driver", error));
+        break;
+      case ADBC_INFO_DRIVER_VERSION:
+        // TODO(lidavidm): fill in driver version
+        RAISE_ADBC(
+            AdbcConnectionGetInfoAppendString(array, info_codes[i], "(unknown)", error));
+        break;
+      case ADBC_INFO_DRIVER_ARROW_VERSION:
+        RAISE_ADBC(AdbcConnectionGetInfoAppendString(array, info_codes[i],
+                                                     NANOARROW_VERSION, error));
+        break;
+      case ADBC_INFO_DRIVER_ADBC_VERSION:
+        RAISE_ADBC(AdbcConnectionGetInfoAppendInt(array, info_codes[i],
+                                                  ADBC_VERSION_1_1_0, error));
+        break;
+      default:
+        // Ignore
+        continue;
+    }
+    CHECK_NA(INTERNAL, ArrowArrayFinishElement(array), error);
+  }
+
+  struct ArrowError na_error = {0};
+  CHECK_NA_DETAIL(INTERNAL, ArrowArrayFinishBuildingDefault(array, &na_error), &na_error,
+                  error);
+
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresConnection::GetInfo(struct AdbcConnection* connection,
+                                           const uint32_t* info_codes,
+                                           size_t info_codes_length,
+                                           struct ArrowArrayStream* out,
+                                           struct AdbcError* error) {
+  if (!info_codes) {
+    info_codes = kSupportedInfoCodes;
+    info_codes_length = sizeof(kSupportedInfoCodes) / sizeof(kSupportedInfoCodes[0]);
+  }
+
+  struct ArrowSchema schema;
+  std::memset(&schema, 0, sizeof(schema));
+  struct ArrowArray array;
+  std::memset(&array, 0, sizeof(array));
+
+  AdbcStatusCode status = PostgresConnectionGetInfoImpl(info_codes, info_codes_length,
+                                                        &schema, &array, error);
+  if (status != ADBC_STATUS_OK) {
+    if (schema.release) schema.release(&schema);
+    if (array.release) array.release(&array);
+    return status;
+  }
+
+  return BatchToArrayStream(&array, &schema, out, error);
+}
+
+AdbcStatusCode PostgresConnection::GetObjects(
+    struct AdbcConnection* connection, int depth, const char* catalog,
+    const char* db_schema, const char* table_name, const char** table_types,
+    const char* column_name, struct ArrowArrayStream* out, struct AdbcError* error) {
+  struct ArrowSchema schema;
+  std::memset(&schema, 0, sizeof(schema));
+  struct ArrowArray array;
+  std::memset(&array, 0, sizeof(array));
+
+  PqGetObjectsHelper helper =
+      PqGetObjectsHelper(conn_, depth, catalog, db_schema, table_name, table_types,
+                         column_name, &schema, &array, error);
+  AdbcStatusCode status = helper.GetObjects();
+
+  if (status != ADBC_STATUS_OK) {
+    if (schema.release) schema.release(&schema);
+    if (array.release) array.release(&array);
+    return status;
+  }
+
+  return BatchToArrayStream(&array, &schema, out, error);
+}
+
+AdbcStatusCode PostgresConnection::GetOption(const char* option, char* value,
+                                             size_t* length, struct AdbcError* error) {
+  std::string output;
+  if (std::strcmp(option, ADBC_CONNECTION_OPTION_CURRENT_CATALOG) == 0) {
+    output = PQdb(conn_);
+  } else if (std::strcmp(option, ADBC_CONNECTION_OPTION_CURRENT_DB_SCHEMA) == 0) {
+    PqResultHelper result_helper{conn_, "SELECT CURRENT_SCHEMA", {}, error};
+    RAISE_ADBC(result_helper.Prepare());
+    RAISE_ADBC(result_helper.Execute());
+    auto it = result_helper.begin();
+    if (it == result_helper.end()) {
+      SetError(error, "[libpq] PostgreSQL returned no rows for 'SELECT CURRENT_SCHEMA'");
+      return ADBC_STATUS_INTERNAL;
+    }
+    output = (*it)[0].data;
+  } else if (std::strcmp(option, ADBC_CONNECTION_OPTION_AUTOCOMMIT) == 0) {
+    output = autocommit_ ? ADBC_OPTION_VALUE_ENABLED : ADBC_OPTION_VALUE_DISABLED;
+  } else {
+    return ADBC_STATUS_NOT_FOUND;
+  }
+
+  if (output.size() + 1 <= *length) {
+    std::memcpy(value, output.c_str(), output.size() + 1);
+  }
+  *length = output.size() + 1;
+  return ADBC_STATUS_OK;
+}
+AdbcStatusCode PostgresConnection::GetOptionBytes(const char* option, uint8_t* value,
+                                                  size_t* length,
+                                                  struct AdbcError* error) {
+  return ADBC_STATUS_NOT_FOUND;
+}
+AdbcStatusCode PostgresConnection::GetOptionInt(const char* option, int64_t* value,
+                                                struct AdbcError* error) {
+  return ADBC_STATUS_NOT_FOUND;
+}
+AdbcStatusCode PostgresConnection::GetOptionDouble(const char* option, double* value,
+                                                   struct AdbcError* error) {
+  return ADBC_STATUS_NOT_FOUND;
+}
+
+AdbcStatusCode PostgresConnectionGetStatisticsImpl(PGconn* conn, const char* db_schema,
+                                                   const char* table_name,
+                                                   struct ArrowSchema* schema,
+                                                   struct ArrowArray* array,
+                                                   struct AdbcError* error) {
+  // Set up schema
+  auto uschema = nanoarrow::UniqueSchema();
+  {
+    ArrowSchemaInit(uschema.get());
+    CHECK_NA(INTERNAL, ArrowSchemaSetTypeStruct(uschema.get(), /*num_columns=*/2), error);
+    CHECK_NA(INTERNAL, ArrowSchemaSetType(uschema->children[0], NANOARROW_TYPE_STRING),
+             error);
+    CHECK_NA(INTERNAL, ArrowSchemaSetName(uschema->children[0], "catalog_name"), error);
+    CHECK_NA(INTERNAL, ArrowSchemaSetType(uschema->children[1], NANOARROW_TYPE_LIST),
+             error);
+    CHECK_NA(INTERNAL, ArrowSchemaSetName(uschema->children[1], "catalog_db_schemas"),
+             error);
+    CHECK_NA(INTERNAL, ArrowSchemaSetTypeStruct(uschema->children[1]->children[0], 2),
+             error);
+    uschema->children[1]->flags &= ~ARROW_FLAG_NULLABLE;
+
+    struct ArrowSchema* db_schema_schema = uschema->children[1]->children[0];
+    CHECK_NA(INTERNAL,
+             ArrowSchemaSetType(db_schema_schema->children[0], NANOARROW_TYPE_STRING),
+             error);
+    CHECK_NA(INTERNAL,
+             ArrowSchemaSetName(db_schema_schema->children[0], "db_schema_name"), error);
+    CHECK_NA(INTERNAL,
+             ArrowSchemaSetType(db_schema_schema->children[1], NANOARROW_TYPE_LIST),
+             error);
+    CHECK_NA(INTERNAL,
+             ArrowSchemaSetName(db_schema_schema->children[1], "db_schema_statistics"),
+             error);
+    CHECK_NA(INTERNAL,
+             ArrowSchemaSetTypeStruct(db_schema_schema->children[1]->children[0], 5),
+             error);
+    db_schema_schema->children[1]->flags &= ~ARROW_FLAG_NULLABLE;
+
+    struct ArrowSchema* statistics_schema = db_schema_schema->children[1]->children[0];
+    CHECK_NA(INTERNAL,
+             ArrowSchemaSetType(statistics_schema->children[0], NANOARROW_TYPE_STRING),
+             error);
+    CHECK_NA(INTERNAL, ArrowSchemaSetName(statistics_schema->children[0], "table_name"),
+             error);
+    statistics_schema->children[0]->flags &= ~ARROW_FLAG_NULLABLE;
+    CHECK_NA(INTERNAL,
+             ArrowSchemaSetType(statistics_schema->children[1], NANOARROW_TYPE_STRING),
+             error);
+    CHECK_NA(INTERNAL, ArrowSchemaSetName(statistics_schema->children[1], "column_name"),
+             error);
+    CHECK_NA(INTERNAL,
+             ArrowSchemaSetType(statistics_schema->children[2], NANOARROW_TYPE_INT16),
+             error);
+    CHECK_NA(INTERNAL,
+             ArrowSchemaSetName(statistics_schema->children[2], "statistic_key"), error);
+    statistics_schema->children[2]->flags &= ~ARROW_FLAG_NULLABLE;
+    CHECK_NA(INTERNAL,
+             ArrowSchemaSetTypeUnion(statistics_schema->children[3],
+                                     NANOARROW_TYPE_DENSE_UNION, 4),
+             error);
+    CHECK_NA(INTERNAL,
+             ArrowSchemaSetName(statistics_schema->children[3], "statistic_value"),
+             error);
+    statistics_schema->children[3]->flags &= ~ARROW_FLAG_NULLABLE;
+    CHECK_NA(INTERNAL,
+             ArrowSchemaSetType(statistics_schema->children[4], NANOARROW_TYPE_BOOL),
+             error);
+    CHECK_NA(
+        INTERNAL,
+        ArrowSchemaSetName(statistics_schema->children[4], "statistic_is_approximate"),
+        error);
+    statistics_schema->children[4]->flags &= ~ARROW_FLAG_NULLABLE;
+
+    struct ArrowSchema* value_schema = statistics_schema->children[3];
+    CHECK_NA(INTERNAL,
+             ArrowSchemaSetType(value_schema->children[0], NANOARROW_TYPE_INT64), error);
+    CHECK_NA(INTERNAL, ArrowSchemaSetName(value_schema->children[0], "int64"), error);
+    CHECK_NA(INTERNAL,
+             ArrowSchemaSetType(value_schema->children[1], NANOARROW_TYPE_UINT64), error);
+    CHECK_NA(INTERNAL, ArrowSchemaSetName(value_schema->children[1], "uint64"), error);
+    CHECK_NA(INTERNAL,
+             ArrowSchemaSetType(value_schema->children[2], NANOARROW_TYPE_DOUBLE), error);
+    CHECK_NA(INTERNAL, ArrowSchemaSetName(value_schema->children[2], "float64"), error);
+    CHECK_NA(INTERNAL,
+             ArrowSchemaSetType(value_schema->children[3], NANOARROW_TYPE_BINARY), error);
+    CHECK_NA(INTERNAL, ArrowSchemaSetName(value_schema->children[3], "binary"), error);
+  }
+
+  // Set up builders
+  struct ArrowError na_error = {0};
+  CHECK_NA_DETAIL(INTERNAL, ArrowArrayInitFromSchema(array, uschema.get(), &na_error),
+                  &na_error, error);
+  CHECK_NA(INTERNAL, ArrowArrayStartAppending(array), error);
+
+  struct ArrowArray* catalog_name_col = array->children[0];
+  struct ArrowArray* catalog_db_schemas_col = array->children[1];
+  struct ArrowArray* catalog_db_schemas_items = catalog_db_schemas_col->children[0];
+  struct ArrowArray* db_schema_name_col = catalog_db_schemas_items->children[0];
+  struct ArrowArray* db_schema_statistics_col = catalog_db_schemas_items->children[1];
+  struct ArrowArray* db_schema_statistics_items = db_schema_statistics_col->children[0];
+  struct ArrowArray* statistics_table_name_col = db_schema_statistics_items->children[0];
+  struct ArrowArray* statistics_column_name_col = db_schema_statistics_items->children[1];
+  struct ArrowArray* statistics_key_col = db_schema_statistics_items->children[2];
+  struct ArrowArray* statistics_value_col = db_schema_statistics_items->children[3];
+  struct ArrowArray* statistics_is_approximate_col =
+      db_schema_statistics_items->children[4];
+  // struct ArrowArray* value_int64_col = statistics_value_col->children[0];
+  // struct ArrowArray* value_uint64_col = statistics_value_col->children[1];
+  struct ArrowArray* value_float64_col = statistics_value_col->children[2];
+  // struct ArrowArray* value_binary_col = statistics_value_col->children[3];
+
+  // Query (could probably be massively improved)
+  std::string query = R"(
+    WITH
+      class AS (
+        SELECT nspname, relname, reltuples
+        FROM pg_namespace
+        INNER JOIN pg_class ON pg_class.relnamespace = pg_namespace.oid
+      )
+    SELECT tablename, attname, null_frac, avg_width, n_distinct, reltuples
+    FROM pg_stats
+    INNER JOIN class ON pg_stats.schemaname = class.nspname AND pg_stats.tablename = class.relname
+    WHERE pg_stats.schemaname = $1 AND tablename LIKE $2
+    ORDER BY tablename
+)";
+
+  CHECK_NA(INTERNAL, ArrowArrayAppendString(catalog_name_col, ArrowCharView(PQdb(conn))),
+           error);
+  CHECK_NA(INTERNAL, ArrowArrayAppendString(db_schema_name_col, ArrowCharView(db_schema)),
+           error);
+
+  constexpr int8_t kStatsVariantFloat64 = 2;
+
+  std::string prev_table;
+
+  {
+    PqResultHelper result_helper{
+        conn, query, {db_schema, table_name ? table_name : "%"}, error};
+    RAISE_ADBC(result_helper.Prepare());
+    RAISE_ADBC(result_helper.Execute());
+
+    for (PqResultRow row : result_helper) {
+      auto reltuples = row[5].ParseDouble();
+      if (!reltuples.first) {
+        SetError(error, "[libpq] Invalid double value in reltuples: '%s'", row[5].data);
+        return ADBC_STATUS_INTERNAL;
+      }
+
+      if (std::strcmp(prev_table.c_str(), row[0].data) != 0) {
+        CHECK_NA(INTERNAL,
+                 ArrowArrayAppendString(statistics_table_name_col,
+                                        ArrowStringView{row[0].data, row[0].len}),
+                 error);
+        CHECK_NA(INTERNAL, ArrowArrayAppendNull(statistics_column_name_col, 1), error);
+        CHECK_NA(INTERNAL,
+                 ArrowArrayAppendInt(statistics_key_col, ADBC_STATISTIC_ROW_COUNT_KEY),
+                 error);
+        CHECK_NA(INTERNAL, ArrowArrayAppendDouble(value_float64_col, reltuples.second),
+                 error);
+        CHECK_NA(INTERNAL,
+                 ArrowArrayFinishUnionElement(statistics_value_col, kStatsVariantFloat64),
+                 error);
+        CHECK_NA(INTERNAL, ArrowArrayAppendInt(statistics_is_approximate_col, 1), error);
+        CHECK_NA(INTERNAL, ArrowArrayFinishElement(db_schema_statistics_items), error);
+        prev_table = std::string(row[0].data, row[0].len);
+      }
+
+      auto null_frac = row[2].ParseDouble();
+      if (!null_frac.first) {
+        SetError(error, "[libpq] Invalid double value in null_frac: '%s'", row[2].data);
+        return ADBC_STATUS_INTERNAL;
+      }
+
+      CHECK_NA(INTERNAL,
+               ArrowArrayAppendString(statistics_table_name_col,
+                                      ArrowStringView{row[0].data, row[0].len}),
+               error);
+      CHECK_NA(INTERNAL,
+               ArrowArrayAppendString(statistics_column_name_col,
+                                      ArrowStringView{row[1].data, row[1].len}),
+               error);
+      CHECK_NA(INTERNAL,
+               ArrowArrayAppendInt(statistics_key_col, ADBC_STATISTIC_NULL_COUNT_KEY),
+               error);
+      CHECK_NA(
+          INTERNAL,
+          ArrowArrayAppendDouble(value_float64_col, null_frac.second * reltuples.second),
+          error);
+      CHECK_NA(INTERNAL,
+               ArrowArrayFinishUnionElement(statistics_value_col, kStatsVariantFloat64),
+               error);
+      CHECK_NA(INTERNAL, ArrowArrayAppendInt(statistics_is_approximate_col, 1), error);
+      CHECK_NA(INTERNAL, ArrowArrayFinishElement(db_schema_statistics_items), error);
+
+      auto average_byte_width = row[3].ParseDouble();
+      if (!average_byte_width.first) {
+        SetError(error, "[libpq] Invalid double value in avg_width: '%s'", row[3].data);
+        return ADBC_STATUS_INTERNAL;
+      }
+
+      CHECK_NA(INTERNAL,
+               ArrowArrayAppendString(statistics_table_name_col,
+                                      ArrowStringView{row[0].data, row[0].len}),
+               error);
+      CHECK_NA(INTERNAL,
+               ArrowArrayAppendString(statistics_column_name_col,
+                                      ArrowStringView{row[1].data, row[1].len}),
+               error);
+      CHECK_NA(
+          INTERNAL,
+          ArrowArrayAppendInt(statistics_key_col, ADBC_STATISTIC_AVERAGE_BYTE_WIDTH_KEY),
+          error);
+      CHECK_NA(INTERNAL,
+               ArrowArrayAppendDouble(value_float64_col, average_byte_width.second),
+               error);
+      CHECK_NA(INTERNAL,
+               ArrowArrayFinishUnionElement(statistics_value_col, kStatsVariantFloat64),
+               error);
+      CHECK_NA(INTERNAL, ArrowArrayAppendInt(statistics_is_approximate_col, 1), error);
+      CHECK_NA(INTERNAL, ArrowArrayFinishElement(db_schema_statistics_items), error);
+
+      auto n_distinct = row[4].ParseDouble();
+      if (!n_distinct.first) {
+        SetError(error, "[libpq] Invalid double value in avg_width: '%s'", row[4].data);
+        return ADBC_STATUS_INTERNAL;
+      }
+
+      CHECK_NA(INTERNAL,
+               ArrowArrayAppendString(statistics_table_name_col,
+                                      ArrowStringView{row[0].data, row[0].len}),
+               error);
+      CHECK_NA(INTERNAL,
+               ArrowArrayAppendString(statistics_column_name_col,
+                                      ArrowStringView{row[1].data, row[1].len}),
+               error);
+      CHECK_NA(INTERNAL,
+               ArrowArrayAppendInt(statistics_key_col, ADBC_STATISTIC_DISTINCT_COUNT_KEY),
+               error);
+      // > If greater than zero, the estimated number of distinct values in
+      // > the column. If less than zero, the negative of the number of
+      // > distinct values divided by the number of rows.
+      // https://www.postgresql.org/docs/current/view-pg-stats.html
+      CHECK_NA(
+          INTERNAL,
+          ArrowArrayAppendDouble(value_float64_col,
+                                 n_distinct.second > 0
+                                     ? n_distinct.second
+                                     : (std::fabs(n_distinct.second) * reltuples.second)),
+          error);
+      CHECK_NA(INTERNAL,
+               ArrowArrayFinishUnionElement(statistics_value_col, kStatsVariantFloat64),
+               error);
+      CHECK_NA(INTERNAL, ArrowArrayAppendInt(statistics_is_approximate_col, 1), error);
+      CHECK_NA(INTERNAL, ArrowArrayFinishElement(db_schema_statistics_items), error);
+    }
+  }
+
+  CHECK_NA(INTERNAL, ArrowArrayFinishElement(db_schema_statistics_col), error);
+  CHECK_NA(INTERNAL, ArrowArrayFinishElement(catalog_db_schemas_items), error);
+  CHECK_NA(INTERNAL, ArrowArrayFinishElement(catalog_db_schemas_col), error);
+  CHECK_NA(INTERNAL, ArrowArrayFinishElement(array), error);
+
+  CHECK_NA_DETAIL(INTERNAL, ArrowArrayFinishBuildingDefault(array, &na_error), &na_error,
+                  error);
+  uschema.move(schema);
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresConnection::GetStatistics(const char* catalog,
+                                                 const char* db_schema,
+                                                 const char* table_name, bool approximate,
+                                                 struct ArrowArrayStream* out,
+                                                 struct AdbcError* error) {
+  // Simplify our jobs here
+  if (!approximate) {
+    SetError(error, "[libpq] Exact statistics are not implemented");
+    return ADBC_STATUS_NOT_IMPLEMENTED;
+  } else if (!db_schema) {
+    SetError(error, "[libpq] Must request statistics for a single schema");
+    return ADBC_STATUS_NOT_IMPLEMENTED;
+  } else if (catalog && std::strcmp(catalog, PQdb(conn_)) != 0) {
+    SetError(error, "[libpq] Can only request statistics for current catalog");
+    return ADBC_STATUS_NOT_IMPLEMENTED;
+  }
+
+  struct ArrowSchema schema;
+  std::memset(&schema, 0, sizeof(schema));
+  struct ArrowArray array;
+  std::memset(&array, 0, sizeof(array));
+
+  AdbcStatusCode status = PostgresConnectionGetStatisticsImpl(
+      conn_, db_schema, table_name, &schema, &array, error);
+  if (status != ADBC_STATUS_OK) {
+    if (schema.release) schema.release(&schema);
+    if (array.release) array.release(&array);
+    return status;
+  }
+
+  return BatchToArrayStream(&array, &schema, out, error);
+}
+
+AdbcStatusCode PostgresConnectionGetStatisticNamesImpl(struct ArrowSchema* schema,
+                                                       struct ArrowArray* array,
+                                                       struct AdbcError* error) {
+  auto uschema = nanoarrow::UniqueSchema();
+  ArrowSchemaInit(uschema.get());
+
+  CHECK_NA(INTERNAL, ArrowSchemaSetType(uschema.get(), NANOARROW_TYPE_STRUCT), error);
+  CHECK_NA(INTERNAL, ArrowSchemaAllocateChildren(uschema.get(), /*num_columns=*/2),
+           error);
+
+  ArrowSchemaInit(uschema.get()->children[0]);
+  CHECK_NA(INTERNAL,
+           ArrowSchemaSetType(uschema.get()->children[0], NANOARROW_TYPE_STRING), error);
+  CHECK_NA(INTERNAL, ArrowSchemaSetName(uschema.get()->children[0], "statistic_name"),
+           error);
+  uschema.get()->children[0]->flags &= ~ARROW_FLAG_NULLABLE;
+
+  ArrowSchemaInit(uschema.get()->children[1]);
+  CHECK_NA(INTERNAL, ArrowSchemaSetType(uschema.get()->children[1], NANOARROW_TYPE_INT16),
+           error);
+  CHECK_NA(INTERNAL, ArrowSchemaSetName(uschema.get()->children[1], "statistic_key"),
+           error);
+  uschema.get()->children[1]->flags &= ~ARROW_FLAG_NULLABLE;
+
+  CHECK_NA(INTERNAL, ArrowArrayInitFromSchema(array, uschema.get(), NULL), error);
+  CHECK_NA(INTERNAL, ArrowArrayStartAppending(array), error);
+  CHECK_NA(INTERNAL, ArrowArrayFinishBuildingDefault(array, NULL), error);
+
+  uschema.move(schema);
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresConnection::GetStatisticNames(struct ArrowArrayStream* out,
+                                                     struct AdbcError* error) {
+  // We don't support any extended statistics, just return an empty stream
+  struct ArrowSchema schema;
+  std::memset(&schema, 0, sizeof(schema));
+  struct ArrowArray array;
+  std::memset(&array, 0, sizeof(array));
+
+  AdbcStatusCode status = PostgresConnectionGetStatisticNamesImpl(&schema, &array, error);
+  if (status != ADBC_STATUS_OK) {
+    if (schema.release) schema.release(&schema);
+    if (array.release) array.release(&array);
+    return status;
+  }
+  return BatchToArrayStream(&array, &schema, out, error);
+
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresConnection::GetTableSchema(const char* catalog,
+                                                  const char* db_schema,
+                                                  const char* table_name,
+                                                  struct ArrowSchema* schema,
+                                                  struct AdbcError* error) {
+  AdbcStatusCode final_status = ADBC_STATUS_OK;
+
+  std::string query =
+      "SELECT attname, atttypid "
+      "FROM pg_catalog.pg_class AS cls "
+      "INNER JOIN pg_catalog.pg_attribute AS attr ON cls.oid = attr.attrelid "
+      "INNER JOIN pg_catalog.pg_type AS typ ON attr.atttypid = typ.oid "
+      "WHERE attr.attnum >= 0 AND cls.oid = $1::regclass::oid";
+
+  std::vector<std::string> params;
+  if (db_schema != nullptr) {
+    params.push_back(std::string(db_schema) + "." + table_name);
+  } else {
+    params.push_back(table_name);
+  }
+
+  PqResultHelper result_helper =
+      PqResultHelper{conn_, std::string(query.c_str()), params, error};
+
+  RAISE_ADBC(result_helper.Prepare());
+  auto result = result_helper.Execute();
+  if (result != ADBC_STATUS_OK) {
+    auto error_code = std::string(error->sqlstate, 5);
+    if ((error_code == "42P01") || (error_code == "42602")) {
+      return ADBC_STATUS_NOT_FOUND;
+    }
+    return result;
+  }
+
+  auto uschema = nanoarrow::UniqueSchema();
+  ArrowSchemaInit(uschema.get());
+  CHECK_NA(INTERNAL, ArrowSchemaSetTypeStruct(uschema.get(), result_helper.NumRows()),
+           error);
+
+  ArrowError na_error;
+  int row_counter = 0;
+  for (auto row : result_helper) {
+    const char* colname = row[0].data;
+    const Oid pg_oid =
+        static_cast<uint32_t>(std::strtol(row[1].data, /*str_end=*/nullptr, /*base=*/10));
+
+    PostgresType pg_type;
+    if (type_resolver_->Find(pg_oid, &pg_type, &na_error) != NANOARROW_OK) {
+      SetError(error, "%s%d%s%s%s%" PRIu32, "Column #", row_counter + 1, " (\"", colname,
+               "\") has unknown type code ", pg_oid);
+      final_status = ADBC_STATUS_NOT_IMPLEMENTED;
+      break;
+    }
+    CHECK_NA(INTERNAL,
+             pg_type.WithFieldName(colname).SetSchema(uschema->children[row_counter]),
+             error);
+    row_counter++;
+  }
+  uschema.move(schema);
+
+  return final_status;
+}
+
+AdbcStatusCode PostgresConnectionGetTableTypesImpl(struct ArrowSchema* schema,
+                                                   struct ArrowArray* array,
+                                                   struct AdbcError* error) {
+  // See 'relkind' in https://www.postgresql.org/docs/current/catalog-pg-class.html
+  auto uschema = nanoarrow::UniqueSchema();
+  ArrowSchemaInit(uschema.get());
+
+  CHECK_NA(INTERNAL, ArrowSchemaSetType(uschema.get(), NANOARROW_TYPE_STRUCT), error);
+  CHECK_NA(INTERNAL, ArrowSchemaAllocateChildren(uschema.get(), /*num_columns=*/1),
+           error);
+  ArrowSchemaInit(uschema.get()->children[0]);
+  CHECK_NA(INTERNAL,
+           ArrowSchemaSetType(uschema.get()->children[0], NANOARROW_TYPE_STRING), error);
+  CHECK_NA(INTERNAL, ArrowSchemaSetName(uschema.get()->children[0], "table_type"), error);
+  uschema.get()->children[0]->flags &= ~ARROW_FLAG_NULLABLE;
+
+  CHECK_NA(INTERNAL, ArrowArrayInitFromSchema(array, uschema.get(), NULL), error);
+  CHECK_NA(INTERNAL, ArrowArrayStartAppending(array), error);
+
+  for (auto const& table_type : kPgTableTypes) {
+    CHECK_NA(INTERNAL,
+             ArrowArrayAppendString(array->children[0],
+                                    ArrowCharView(table_type.first.c_str())),
+             error);
+    CHECK_NA(INTERNAL, ArrowArrayFinishElement(array), error);
+  }
+
+  CHECK_NA(INTERNAL, ArrowArrayFinishBuildingDefault(array, NULL), error);
+
+  uschema.move(schema);
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresConnection::GetTableTypes(struct AdbcConnection* connection,
+                                                 struct ArrowArrayStream* out,
+                                                 struct AdbcError* error) {
+  struct ArrowSchema schema;
+  std::memset(&schema, 0, sizeof(schema));
+  struct ArrowArray array;
+  std::memset(&array, 0, sizeof(array));
+
+  AdbcStatusCode status = PostgresConnectionGetTableTypesImpl(&schema, &array, error);
+  if (status != ADBC_STATUS_OK) {
+    if (schema.release) schema.release(&schema);
+    if (array.release) array.release(&array);
+    return status;
+  }
+  return BatchToArrayStream(&array, &schema, out, error);
+}
+
+AdbcStatusCode PostgresConnection::Init(struct AdbcDatabase* database,
+                                        struct AdbcError* error) {
+  if (!database || !database->private_data) {
+    SetError(error, "[libpq] Must provide an initialized AdbcDatabase");
+    return ADBC_STATUS_INVALID_ARGUMENT;
+  }
+  database_ =
+      *reinterpret_cast<std::shared_ptr<PostgresDatabase>*>(database->private_data);
+  type_resolver_ = database_->type_resolver();
+
+  RAISE_ADBC(database_->Connect(&conn_, error));
+
+  cancel_ = PQgetCancel(conn_);
+  if (!cancel_) {
+    SetError(error, "[libpq] Could not initialize PGcancel");
+    return ADBC_STATUS_UNKNOWN;
+  }
+
+  std::ignore = PQsetNoticeProcessor(conn_, SilentNoticeProcessor, nullptr);
+
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresConnection::Release(struct AdbcError* error) {
+  if (cancel_) {
+    PQfreeCancel(cancel_);
+    cancel_ = nullptr;
+  }
+  if (conn_) {
+    return database_->Disconnect(&conn_, error);
+  }
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresConnection::Rollback(struct AdbcError* error) {
+  if (autocommit_) {
+    SetError(error, "%s", "[libpq] Cannot rollback when autocommit is enabled");
+    return ADBC_STATUS_INVALID_STATE;
+  }
+
+  PGresult* result = PQexec(conn_, "ROLLBACK");
+  if (PQresultStatus(result) != PGRES_COMMAND_OK) {
+    SetError(error, "%s%s", "[libpq] Failed to rollback: ", PQerrorMessage(conn_));
+    PQclear(result);
+    return ADBC_STATUS_IO;
+  }
+  PQclear(result);
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresConnection::SetOption(const char* key, const char* value,
+                                             struct AdbcError* error) {
+  if (std::strcmp(key, ADBC_CONNECTION_OPTION_AUTOCOMMIT) == 0) {
+    bool autocommit = true;
+    if (std::strcmp(value, ADBC_OPTION_VALUE_ENABLED) == 0) {
+      autocommit = true;
+    } else if (std::strcmp(value, ADBC_OPTION_VALUE_DISABLED) == 0) {
+      autocommit = false;
+    } else {
+      SetError(error, "%s%s%s%s", "[libpq] Invalid value for option ", key, ": ", value);
+      return ADBC_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (autocommit != autocommit_) {
+      const char* query = autocommit ? "COMMIT" : "BEGIN TRANSACTION";
+
+      PGresult* result = PQexec(conn_, query);
+      if (PQresultStatus(result) != PGRES_COMMAND_OK) {
+        SetError(error, "%s%s",
+                 "[libpq] Failed to update autocommit: ", PQerrorMessage(conn_));
+        PQclear(result);
+        return ADBC_STATUS_IO;
+      }
+      PQclear(result);
+      autocommit_ = autocommit;
+    }
+    return ADBC_STATUS_OK;
+  } else if (std::strcmp(key, ADBC_CONNECTION_OPTION_CURRENT_DB_SCHEMA) == 0) {
+    // PostgreSQL doesn't accept a parameter here
+    PqResultHelper result_helper{
+        conn_, std::string("SET search_path TO ") + value, {}, error};
+    RAISE_ADBC(result_helper.Prepare());
+    RAISE_ADBC(result_helper.Execute());
+    return ADBC_STATUS_OK;
+  }
+  SetError(error, "%s%s", "[libpq] Unknown option ", key);
+  return ADBC_STATUS_NOT_IMPLEMENTED;
+}
+
+AdbcStatusCode PostgresConnection::SetOptionBytes(const char* key, const uint8_t* value,
+                                                  size_t length,
+                                                  struct AdbcError* error) {
+  SetError(error, "%s%s", "[libpq] Unknown option ", key);
+  return ADBC_STATUS_NOT_IMPLEMENTED;
+}
+
+AdbcStatusCode PostgresConnection::SetOptionDouble(const char* key, double value,
+                                                   struct AdbcError* error) {
+  SetError(error, "%s%s", "[libpq] Unknown option ", key);
+  return ADBC_STATUS_NOT_IMPLEMENTED;
+}
+
+AdbcStatusCode PostgresConnection::SetOptionInt(const char* key, int64_t value,
+                                                struct AdbcError* error) {
+  SetError(error, "%s%s", "[libpq] Unknown option ", key);
+  return ADBC_STATUS_NOT_IMPLEMENTED;
+}
+
+}  // namespace adbcpq

--- a/c/driver/netezza/connection.h
+++ b/c/driver/netezza/connection.h
@@ -1,0 +1,89 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include <adbc.h>
+#include <libpq-fe.h>
+
+#include "postgres_type.h"
+
+namespace adbcpq {
+class PostgresDatabase;
+class PostgresConnection {
+ public:
+  PostgresConnection()
+      : database_(nullptr), conn_(nullptr), cancel_(nullptr), autocommit_(true) {}
+
+  AdbcStatusCode Cancel(struct AdbcError* error);
+  AdbcStatusCode Commit(struct AdbcError* error);
+  AdbcStatusCode GetInfo(struct AdbcConnection* connection, const uint32_t* info_codes,
+                         size_t info_codes_length, struct ArrowArrayStream* out,
+                         struct AdbcError* error);
+  AdbcStatusCode GetObjects(struct AdbcConnection* connection, int depth,
+                            const char* catalog, const char* db_schema,
+                            const char* table_name, const char** table_types,
+                            const char* column_name, struct ArrowArrayStream* out,
+                            struct AdbcError* error);
+  AdbcStatusCode GetOption(const char* option, char* value, size_t* length,
+                           struct AdbcError* error);
+  AdbcStatusCode GetOptionBytes(const char* option, uint8_t* value, size_t* length,
+                                struct AdbcError* error);
+  AdbcStatusCode GetOptionDouble(const char* option, double* value,
+                                 struct AdbcError* error);
+  AdbcStatusCode GetOptionInt(const char* option, int64_t* value,
+                              struct AdbcError* error);
+  AdbcStatusCode GetStatistics(const char* catalog, const char* db_schema,
+                               const char* table_name, bool approximate,
+                               struct ArrowArrayStream* out, struct AdbcError* error);
+  AdbcStatusCode GetStatisticNames(struct ArrowArrayStream* out, struct AdbcError* error);
+  AdbcStatusCode GetTableSchema(const char* catalog, const char* db_schema,
+                                const char* table_name, struct ArrowSchema* schema,
+                                struct AdbcError* error);
+  AdbcStatusCode GetTableTypes(struct AdbcConnection* connection,
+                               struct ArrowArrayStream* out, struct AdbcError* error);
+  AdbcStatusCode Init(struct AdbcDatabase* database, struct AdbcError* error);
+  AdbcStatusCode Release(struct AdbcError* error);
+  AdbcStatusCode Rollback(struct AdbcError* error);
+  AdbcStatusCode SetOption(const char* key, const char* value, struct AdbcError* error);
+  AdbcStatusCode SetOptionBytes(const char* key, const uint8_t* value, size_t length,
+                                struct AdbcError* error);
+  AdbcStatusCode SetOptionDouble(const char* key, double value, struct AdbcError* error);
+  AdbcStatusCode SetOptionInt(const char* key, int64_t value, struct AdbcError* error);
+
+  PGconn* conn() const { return conn_; }
+  const std::shared_ptr<PostgresTypeResolver>& type_resolver() const {
+    return type_resolver_;
+  }
+  bool autocommit() const { return autocommit_; }
+
+ private:
+  AdbcStatusCode PostgresConnectionGetInfoImpl(const uint32_t* info_codes,
+                                               size_t info_codes_length,
+                                               struct ArrowSchema* schema,
+                                               struct ArrowArray* array,
+                                               struct AdbcError* error);
+  std::shared_ptr<PostgresDatabase> database_;
+  std::shared_ptr<PostgresTypeResolver> type_resolver_;
+  PGconn* conn_;
+  PGcancel* cancel_;
+  bool autocommit_;
+};
+}  // namespace adbcpq

--- a/c/driver/netezza/database.cc
+++ b/c/driver/netezza/database.cc
@@ -1,0 +1,302 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "database.h"
+
+#include <cinttypes>
+#include <cstring>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <adbc.h>
+#include <libpq-fe.h>
+#include <nanoarrow/nanoarrow.h>
+
+#include "common/utils.h"
+
+namespace adbcpq {
+
+PostgresDatabase::PostgresDatabase() : open_connections_(0) {
+  type_resolver_ = std::make_shared<PostgresTypeResolver>();
+}
+PostgresDatabase::~PostgresDatabase() = default;
+
+AdbcStatusCode PostgresDatabase::GetOption(const char* option, char* value,
+                                           size_t* length, struct AdbcError* error) {
+  return ADBC_STATUS_NOT_FOUND;
+}
+AdbcStatusCode PostgresDatabase::GetOptionBytes(const char* option, uint8_t* value,
+                                                size_t* length, struct AdbcError* error) {
+  return ADBC_STATUS_NOT_FOUND;
+}
+AdbcStatusCode PostgresDatabase::GetOptionInt(const char* option, int64_t* value,
+                                              struct AdbcError* error) {
+  return ADBC_STATUS_NOT_FOUND;
+}
+AdbcStatusCode PostgresDatabase::GetOptionDouble(const char* option, double* value,
+                                                 struct AdbcError* error) {
+  return ADBC_STATUS_NOT_FOUND;
+}
+
+AdbcStatusCode PostgresDatabase::Init(struct AdbcError* error) {
+  // Connect to validate the parameters.
+  return RebuildTypeResolver(error);
+}
+
+AdbcStatusCode PostgresDatabase::Release(struct AdbcError* error) {
+  if (open_connections_ != 0) {
+    SetError(error, "%s%" PRId32 "%s", "[libpq] Database released with ",
+             open_connections_, " open connections");
+    return ADBC_STATUS_INVALID_STATE;
+  }
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresDatabase::SetOption(const char* key, const char* value,
+                                           struct AdbcError* error) {
+  if (strcmp(key, "uri") == 0) {
+    uri_ = value;
+  } else {
+    SetError(error, "%s%s", "[libpq] Unknown database option ", key);
+    return ADBC_STATUS_NOT_IMPLEMENTED;
+  }
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresDatabase::SetOptionBytes(const char* key, const uint8_t* value,
+                                                size_t length, struct AdbcError* error) {
+  SetError(error, "%s%s", "[libpq] Unknown option ", key);
+  return ADBC_STATUS_NOT_IMPLEMENTED;
+}
+
+AdbcStatusCode PostgresDatabase::SetOptionDouble(const char* key, double value,
+                                                 struct AdbcError* error) {
+  SetError(error, "%s%s", "[libpq] Unknown option ", key);
+  return ADBC_STATUS_NOT_IMPLEMENTED;
+}
+
+AdbcStatusCode PostgresDatabase::SetOptionInt(const char* key, int64_t value,
+                                              struct AdbcError* error) {
+  SetError(error, "%s%s", "[libpq] Unknown option ", key);
+  return ADBC_STATUS_NOT_IMPLEMENTED;
+}
+
+AdbcStatusCode PostgresDatabase::Connect(PGconn** conn, struct AdbcError* error) {
+  if (uri_.empty()) {
+    SetError(error, "%s",
+             "[libpq] Must set database option 'uri' before creating a connection");
+    return ADBC_STATUS_INVALID_STATE;
+  }
+  *conn = PQconnectdb(uri_.c_str());
+  if (PQstatus(*conn) != CONNECTION_OK) {
+    SetError(error, "%s%s", "[libpq] Failed to connect: ", PQerrorMessage(*conn));
+    PQfinish(*conn);
+    *conn = nullptr;
+    return ADBC_STATUS_IO;
+  }
+  open_connections_++;
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresDatabase::Disconnect(PGconn** conn, struct AdbcError* error) {
+  PQfinish(*conn);
+  *conn = nullptr;
+  if (--open_connections_ < 0) {
+    SetError(error, "%s", "[libpq] Open connection count underflowed");
+    return ADBC_STATUS_INTERNAL;
+  }
+  return ADBC_STATUS_OK;
+}
+
+// Helpers for building the type resolver from queries
+static inline int32_t InsertPgAttributeResult(
+    PGresult* result, const std::shared_ptr<PostgresTypeResolver>& resolver);
+
+static inline int32_t InsertPgTypeResult(
+    PGresult* result, const std::shared_ptr<PostgresTypeResolver>& resolver);
+
+AdbcStatusCode PostgresDatabase::RebuildTypeResolver(struct AdbcError* error) {
+  PGconn* conn = nullptr;
+  AdbcStatusCode final_status = Connect(&conn, error);
+  if (final_status != ADBC_STATUS_OK) {
+    return final_status;
+  }
+
+  // We need a few queries to build the resolver. The current strategy might
+  // fail for some recursive definitions (e.g., arrays of records of arrays).
+  // First, one on the pg_attribute table to resolve column names/oids for
+  // record types.
+  const std::string kColumnsQuery = R"(
+SELECT
+    attrelid,
+    attname,
+    atttypid
+FROM
+    pg_catalog.pg_attribute
+ORDER BY
+    attrelid, attnum
+)";
+
+  // Second, a query of the pg_type table. This query may need a few attempts to handle
+  // recursive definitions (e.g., record types with array column). This currently won't
+  // handle range types because those rows don't have child OID information. Arrays types
+  // are inserted after a successful insert of the element type.
+  const std::string kTypeQuery = R"(
+SELECT
+    oid,
+    typname,
+    typreceive,
+    typbasetype,
+    typarray,
+    typrelid
+FROM
+    pg_catalog.pg_type
+WHERE
+    (typreceive != 0 OR typname = 'aclitem') AND typtype != 'r' AND typreceive::TEXT != 'array_recv'
+ORDER BY
+    oid
+)";
+
+  // Create a new type resolver (this instance's type_resolver_ member
+  // will be updated at the end if this succeeds).
+  auto resolver = std::make_shared<PostgresTypeResolver>();
+
+  // Insert record type definitions (this includes table schemas)
+  PGresult* result = PQexec(conn, kColumnsQuery.c_str());
+  ExecStatusType pq_status = PQresultStatus(result);
+  if (pq_status == PGRES_TUPLES_OK) {
+    InsertPgAttributeResult(result, resolver);
+  } else {
+    SetError(error, "%s%s",
+             "[libpq] Failed to build type mapping table: ", PQerrorMessage(conn));
+    final_status = ADBC_STATUS_IO;
+  }
+
+  PQclear(result);
+
+  // Attempt filling the resolver a few times to handle recursive definitions.
+  int32_t max_attempts = 3;
+  for (int32_t i = 0; i < max_attempts; i++) {
+    result = PQexec(conn, kTypeQuery.c_str());
+    ExecStatusType pq_status = PQresultStatus(result);
+    if (pq_status == PGRES_TUPLES_OK) {
+      InsertPgTypeResult(result, resolver);
+    } else {
+      SetError(error, "%s%s",
+               "[libpq] Failed to build type mapping table: ", PQerrorMessage(conn));
+      final_status = ADBC_STATUS_IO;
+    }
+
+    PQclear(result);
+    if (final_status != ADBC_STATUS_OK) {
+      break;
+    }
+  }
+
+  // Disconnect since PostgreSQL connections can be heavy.
+  {
+    AdbcStatusCode status = Disconnect(&conn, error);
+    if (status != ADBC_STATUS_OK) final_status = status;
+  }
+
+  if (final_status == ADBC_STATUS_OK) {
+    type_resolver_ = std::move(resolver);
+  }
+
+  return final_status;
+}
+
+static inline int32_t InsertPgAttributeResult(
+    PGresult* result, const std::shared_ptr<PostgresTypeResolver>& resolver) {
+  int num_rows = PQntuples(result);
+  std::vector<std::pair<std::string, uint32_t>> columns;
+  uint32_t current_type_oid = 0;
+  int32_t n_added = 0;
+
+  for (int row = 0; row < num_rows; row++) {
+    const uint32_t type_oid = static_cast<uint32_t>(
+        std::strtol(PQgetvalue(result, row, 0), /*str_end=*/nullptr, /*base=*/10));
+    const char* col_name = PQgetvalue(result, row, 1);
+    const uint32_t col_oid = static_cast<uint32_t>(
+        std::strtol(PQgetvalue(result, row, 2), /*str_end=*/nullptr, /*base=*/10));
+
+    if (type_oid != current_type_oid && !columns.empty()) {
+      resolver->InsertClass(current_type_oid, columns);
+      columns.clear();
+      current_type_oid = type_oid;
+      n_added++;
+    }
+
+    columns.push_back({col_name, col_oid});
+  }
+
+  if (!columns.empty()) {
+    resolver->InsertClass(current_type_oid, columns);
+    n_added++;
+  }
+
+  return n_added;
+}
+
+static inline int32_t InsertPgTypeResult(
+    PGresult* result, const std::shared_ptr<PostgresTypeResolver>& resolver) {
+  int num_rows = PQntuples(result);
+  PostgresTypeResolver::Item item;
+  int32_t n_added = 0;
+
+  for (int row = 0; row < num_rows; row++) {
+    const uint32_t oid = static_cast<uint32_t>(
+        std::strtol(PQgetvalue(result, row, 0), /*str_end=*/nullptr, /*base=*/10));
+    const char* typname = PQgetvalue(result, row, 1);
+    const char* typreceive = PQgetvalue(result, row, 2);
+    const uint32_t typbasetype = static_cast<uint32_t>(
+        std::strtol(PQgetvalue(result, row, 3), /*str_end=*/nullptr, /*base=*/10));
+    const uint32_t typarray = static_cast<uint32_t>(
+        std::strtol(PQgetvalue(result, row, 4), /*str_end=*/nullptr, /*base=*/10));
+    const uint32_t typrelid = static_cast<uint32_t>(
+        std::strtol(PQgetvalue(result, row, 5), /*str_end=*/nullptr, /*base=*/10));
+
+    // Special case the aclitem because it shows up in a bunch of internal tables
+    if (strcmp(typname, "aclitem") == 0) {
+      typreceive = "aclitem_recv";
+    }
+
+    item.oid = oid;
+    item.typname = typname;
+    item.typreceive = typreceive;
+    item.class_oid = typrelid;
+    item.base_oid = typbasetype;
+
+    int result = resolver->Insert(item, nullptr);
+
+    // If there's an array type and the insert succeeded, add that now too
+    if (result == NANOARROW_OK && typarray != 0) {
+      std::string array_typname = "_" + std::string(typname);
+      item.oid = typarray;
+      item.typname = array_typname.c_str();
+      item.typreceive = "array_recv";
+      item.child_oid = oid;
+
+      resolver->Insert(item, nullptr);
+    }
+  }
+
+  return n_added;
+}
+
+}  // namespace adbcpq

--- a/c/driver/netezza/database.h
+++ b/c/driver/netezza/database.h
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include <adbc.h>
+#include <libpq-fe.h>
+
+#include "postgres_type.h"
+
+namespace adbcpq {
+class PostgresDatabase {
+ public:
+  PostgresDatabase();
+  ~PostgresDatabase();
+
+  // Public ADBC API
+
+  AdbcStatusCode Init(struct AdbcError* error);
+  AdbcStatusCode Release(struct AdbcError* error);
+  AdbcStatusCode GetOption(const char* option, char* value, size_t* length,
+                           struct AdbcError* error);
+  AdbcStatusCode GetOptionBytes(const char* option, uint8_t* value, size_t* length,
+                                struct AdbcError* error);
+  AdbcStatusCode GetOptionDouble(const char* option, double* value,
+                                 struct AdbcError* error);
+  AdbcStatusCode GetOptionInt(const char* option, int64_t* value,
+                              struct AdbcError* error);
+  AdbcStatusCode SetOption(const char* key, const char* value, struct AdbcError* error);
+  AdbcStatusCode SetOptionBytes(const char* key, const uint8_t* value, size_t length,
+                                struct AdbcError* error);
+  AdbcStatusCode SetOptionDouble(const char* key, double value, struct AdbcError* error);
+  AdbcStatusCode SetOptionInt(const char* key, int64_t value, struct AdbcError* error);
+
+  // Internal implementation
+
+  AdbcStatusCode Connect(PGconn** conn, struct AdbcError* error);
+  AdbcStatusCode Disconnect(PGconn** conn, struct AdbcError* error);
+  const std::shared_ptr<PostgresTypeResolver>& type_resolver() const {
+    return type_resolver_;
+  }
+
+  AdbcStatusCode RebuildTypeResolver(struct AdbcError* error);
+
+ private:
+  int32_t open_connections_;
+  std::string uri_;
+  std::shared_ptr<PostgresTypeResolver> type_resolver_;
+};
+}  // namespace adbcpq
+
+extern "C" {
+/// For applications that want to use the driver struct directly, this gives
+/// them access to the Init routine.
+ADBC_EXPORT
+AdbcStatusCode PostgresqlDriverInit(int, void*, struct AdbcError*);
+}

--- a/c/driver/netezza/error.cc
+++ b/c/driver/netezza/error.cc
@@ -1,0 +1,100 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "error.h"
+
+#include <postgres_ext.h>
+#include <stdarg.h>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <libpq-fe.h>
+
+#include "common/utils.h"
+
+namespace adbcpq {
+
+namespace {
+struct DetailField {
+  int code;
+  std::string key;
+};
+
+static const std::vector<DetailField> kDetailFields = {
+    {PG_DIAG_COLUMN_NAME, "PG_DIAG_COLUMN_NAME"},
+    {PG_DIAG_CONTEXT, "PG_DIAG_CONTEXT"},
+    {PG_DIAG_CONSTRAINT_NAME, "PG_DIAG_CONSTRAINT_NAME"},
+    {PG_DIAG_DATATYPE_NAME, "PG_DIAG_DATATYPE_NAME"},
+    {PG_DIAG_INTERNAL_POSITION, "PG_DIAG_INTERNAL_POSITION"},
+    {PG_DIAG_INTERNAL_QUERY, "PG_DIAG_INTERNAL_QUERY"},
+    {PG_DIAG_MESSAGE_PRIMARY, "PG_DIAG_MESSAGE_PRIMARY"},
+    {PG_DIAG_MESSAGE_DETAIL, "PG_DIAG_MESSAGE_DETAIL"},
+    {PG_DIAG_MESSAGE_HINT, "PG_DIAG_MESSAGE_HINT"},
+    {PG_DIAG_SEVERITY_NONLOCALIZED, "PG_DIAG_SEVERITY_NONLOCALIZED"},
+    {PG_DIAG_SQLSTATE, "PG_DIAG_SQLSTATE"},
+    {PG_DIAG_STATEMENT_POSITION, "PG_DIAG_STATEMENT_POSITION"},
+    {PG_DIAG_SCHEMA_NAME, "PG_DIAG_SCHEMA_NAME"},
+    {PG_DIAG_TABLE_NAME, "PG_DIAG_TABLE_NAME"},
+};
+}  // namespace
+
+AdbcStatusCode SetError(struct AdbcError* error, PGresult* result, const char* format,
+                        ...) {
+  va_list args;
+  va_start(args, format);
+  SetErrorVariadic(error, format, args);
+  va_end(args);
+
+  AdbcStatusCode code = ADBC_STATUS_IO;
+
+  const char* sqlstate = PQresultErrorField(result, PG_DIAG_SQLSTATE);
+  if (sqlstate) {
+    // https://www.postgresql.org/docs/current/errcodes-appendix.html
+    // This can be extended in the future
+    if (std::strcmp(sqlstate, "57014") == 0) {
+      code = ADBC_STATUS_CANCELLED;
+    } else if (std::strcmp(sqlstate, "42P01") == 0 ||
+               std::strcmp(sqlstate, "42602") == 0) {
+      code = ADBC_STATUS_NOT_FOUND;
+    } else if (std::strncmp(sqlstate, "42", 0) == 0) {
+      // Class 42 — Syntax Error or Access Rule Violation
+      code = ADBC_STATUS_INVALID_ARGUMENT;
+    }
+
+    static_assert(sizeof(error->sqlstate) == 5, "");
+    // N.B. strncpy generates warnings when used for this purpose
+    int i = 0;
+    for (; sqlstate[i] != '\0' && i < 5; i++) {
+      error->sqlstate[i] = sqlstate[i];
+    }
+    for (; i < 5; i++) {
+      error->sqlstate[i] = '\0';
+    }
+  }
+
+  for (const auto& field : kDetailFields) {
+    const char* value = PQresultErrorField(result, field.code);
+    if (value) {
+      AppendErrorDetail(error, field.key.c_str(), reinterpret_cast<const uint8_t*>(value),
+                        std::strlen(value));
+    }
+  }
+  return code;
+}
+
+}  // namespace adbcpq

--- a/c/driver/netezza/error.h
+++ b/c/driver/netezza/error.h
@@ -1,0 +1,42 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Error handling utilities.
+
+#pragma once
+
+#include <adbc.h>
+#include <libpq-fe.h>
+
+namespace adbcpq {
+
+// The printf checking attribute doesn't work properly on gcc 4.8
+// and results in spurious compiler warnings
+#if defined(__clang__) || (defined(__GNUC__) && __GNUC__ >= 5)
+#define ADBC_CHECK_PRINTF_ATTRIBUTE(x, y) __attribute__((format(printf, x, y)))
+#else
+#define ADBC_CHECK_PRINTF_ATTRIBUTE(x, y)
+#endif
+
+/// \brief Set an error based on a PGresult, inferring the proper ADBC status
+///   code from the PGresult.
+AdbcStatusCode SetError(struct AdbcError* error, PGresult* result, const char* format,
+                        ...) ADBC_CHECK_PRINTF_ATTRIBUTE(3, 4);
+
+#undef ADBC_CHECK_PRINTF_ATTRIBUTE
+
+}  // namespace adbcpq

--- a/c/driver/netezza/postgres_copy_reader.h
+++ b/c/driver/netezza/postgres_copy_reader.h
@@ -1,0 +1,1528 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+// Windows
+#define NOMINMAX
+
+#include <algorithm>
+#include <cerrno>
+#include <cinttypes>
+#include <cstdint>
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <nanoarrow/nanoarrow.hpp>
+
+#include "common/utils.h"
+#include "postgres_type.h"
+#include "postgres_util.h"
+
+// R 3.6 / Windows builds on a very old toolchain that does not define ENODATA
+#if defined(_WIN32) && !defined(MSVC) && !defined(ENODATA)
+#define ENODATA 120
+#endif
+
+namespace adbcpq {
+
+// "PGCOPY\n\377\r\n\0"
+static int8_t kPgCopyBinarySignature[] = {0x50, 0x47, 0x43, 0x4F,
+                                          0x50, 0x59, 0x0A, static_cast<int8_t>(0xFF),
+                                          0x0D, 0x0A, 0x00};
+
+// The maximum value in seconds that can be converted into microseconds
+// without overflow
+constexpr int64_t kMaxSafeSecondsToMicros = 9223372036854L;
+
+// The minimum value in seconds that can be converted into microseconds
+// without overflow
+constexpr int64_t kMinSafeSecondsToMicros = -9223372036854L;
+
+// The maximum value in milliseconds that can be converted into microseconds
+// without overflow
+constexpr int64_t kMaxSafeMillisToMicros = 9223372036854775L;
+
+// The minimum value in milliseconds that can be converted into microseconds
+// without overflow
+constexpr int64_t kMinSafeMillisToMicros = -9223372036854775L;
+
+// The maximum value in microseconds that can be converted into nanoseconds
+// without overflow
+constexpr int64_t kMaxSafeMicrosToNanos = 9223372036854775L;
+
+// The minimum value in microseconds that can be converted into nanoseconds
+// without overflow
+constexpr int64_t kMinSafeMicrosToNanos = -9223372036854775L;
+
+// 2000-01-01 00:00:00.000000 in microseconds
+constexpr int64_t kPostgresTimestampEpoch = 946684800000000L;
+
+// Read a value from the buffer without checking the buffer size. Advances
+// the cursor of data and reduces its size by sizeof(T).
+template <typename T>
+inline T ReadUnsafe(ArrowBufferView* data) {
+  T out;
+  memcpy(&out, data->data.data, sizeof(T));
+  out = SwapNetworkToHost(out);
+  data->data.as_uint8 += sizeof(T);
+  data->size_bytes -= sizeof(T);
+  return out;
+}
+
+// Define some explicit specializations for types that don't have a SwapNetworkToHost
+// overload.
+template <>
+inline int8_t ReadUnsafe(ArrowBufferView* data) {
+  int8_t out = data->data.as_int8[0];
+  data->data.as_uint8 += sizeof(int8_t);
+  data->size_bytes -= sizeof(int8_t);
+  return out;
+}
+
+template <>
+inline int16_t ReadUnsafe(ArrowBufferView* data) {
+  return static_cast<int16_t>(ReadUnsafe<uint16_t>(data));
+}
+
+template <>
+inline int32_t ReadUnsafe(ArrowBufferView* data) {
+  return static_cast<int32_t>(ReadUnsafe<uint32_t>(data));
+}
+
+template <>
+inline int64_t ReadUnsafe(ArrowBufferView* data) {
+  return static_cast<int64_t>(ReadUnsafe<uint64_t>(data));
+}
+
+template <typename T>
+ArrowErrorCode ReadChecked(ArrowBufferView* data, T* out, ArrowError* error) {
+  if (data->size_bytes < static_cast<int64_t>(sizeof(T))) {
+    ArrowErrorSet(error, "Unexpected end of input (expected %d bytes but found %ld)",
+                  static_cast<int>(sizeof(T)),
+                  static_cast<long>(data->size_bytes));  // NOLINT(runtime/int)
+    return EINVAL;
+  }
+
+  *out = ReadUnsafe<T>(data);
+  return NANOARROW_OK;
+}
+
+// Write a value to a buffer without checking the buffer size. Advances
+// the cursor of buffer and reduces it by sizeof(T)
+template <typename T>
+inline void WriteUnsafe(ArrowBuffer* buffer, T in) {
+  const T value = SwapNetworkToHost(in);
+  ArrowBufferAppendUnsafe(buffer, &value, sizeof(T));
+}
+
+template <>
+inline void WriteUnsafe(ArrowBuffer* buffer, int8_t in) {
+  ArrowBufferAppendUnsafe(buffer, &in, sizeof(int8_t));
+}
+
+template <>
+inline void WriteUnsafe(ArrowBuffer* buffer, int16_t in) {
+  WriteUnsafe<uint16_t>(buffer, in);
+}
+
+template <>
+inline void WriteUnsafe(ArrowBuffer* buffer, int32_t in) {
+  WriteUnsafe<uint32_t>(buffer, in);
+}
+
+template <>
+inline void WriteUnsafe(ArrowBuffer* buffer, int64_t in) {
+  WriteUnsafe<uint64_t>(buffer, in);
+}
+
+template <typename T>
+ArrowErrorCode WriteChecked(ArrowBuffer* buffer, T in, ArrowError* error) {
+  NANOARROW_RETURN_NOT_OK(ArrowBufferReserve(buffer, sizeof(T)));
+  WriteUnsafe<T>(buffer, in);
+  return NANOARROW_OK;
+}
+
+class PostgresCopyFieldReader {
+ public:
+  PostgresCopyFieldReader() : validity_(nullptr), offsets_(nullptr), data_(nullptr) {
+    memset(&schema_view_, 0, sizeof(ArrowSchemaView));
+  }
+
+  virtual ~PostgresCopyFieldReader() {}
+
+  void Init(const PostgresType& pg_type) { pg_type_ = pg_type; }
+
+  const PostgresType& InputType() const { return pg_type_; }
+
+  virtual ArrowErrorCode InitSchema(ArrowSchema* schema) {
+    NANOARROW_RETURN_NOT_OK(ArrowSchemaViewInit(&schema_view_, schema, nullptr));
+    return NANOARROW_OK;
+  }
+
+  virtual ArrowErrorCode InitArray(ArrowArray* array) {
+    // Cache some buffer pointers
+    validity_ = ArrowArrayValidityBitmap(array);
+    for (int32_t i = 0; i < 3; i++) {
+      switch (schema_view_.layout.buffer_type[i]) {
+        case NANOARROW_BUFFER_TYPE_DATA_OFFSET:
+          if (schema_view_.layout.element_size_bits[i] == 32) {
+            offsets_ = ArrowArrayBuffer(array, i);
+          }
+          break;
+        case NANOARROW_BUFFER_TYPE_DATA:
+          data_ = ArrowArrayBuffer(array, i);
+          break;
+        default:
+          break;
+      }
+    }
+
+    return NANOARROW_OK;
+  }
+
+  virtual ArrowErrorCode Read(ArrowBufferView* data, int32_t field_size_bytes,
+                              ArrowArray* array, ArrowError* error) {
+    return ENOTSUP;
+  }
+
+  virtual ArrowErrorCode FinishArray(ArrowArray* array, ArrowError* error) {
+    return NANOARROW_OK;
+  }
+
+ protected:
+  PostgresType pg_type_;
+  ArrowSchemaView schema_view_;
+  ArrowBitmap* validity_;
+  ArrowBuffer* offsets_;
+  ArrowBuffer* data_;
+  std::vector<std::unique_ptr<PostgresCopyFieldReader>> children_;
+
+  ArrowErrorCode AppendValid(ArrowArray* array) {
+    if (validity_->buffer.data != nullptr) {
+      NANOARROW_RETURN_NOT_OK(ArrowBitmapAppend(validity_, true, 1));
+    }
+
+    array->length++;
+    return NANOARROW_OK;
+  }
+};
+
+// Reader for a Postgres boolean (one byte -> bitmap)
+class PostgresCopyBooleanFieldReader : public PostgresCopyFieldReader {
+ public:
+  ArrowErrorCode Read(ArrowBufferView* data, int32_t field_size_bytes, ArrowArray* array,
+                      ArrowError* error) override {
+    if (field_size_bytes <= 0) {
+      return ArrowArrayAppendNull(array, 1);
+    }
+
+    if (field_size_bytes != 1) {
+      ArrowErrorSet(error, "Expected field with one byte but found field with %d bytes",
+                    static_cast<int>(field_size_bytes));  // NOLINT(runtime/int)
+      return EINVAL;
+    }
+
+    int64_t bytes_required = _ArrowBytesForBits(array->length + 1);
+    if (bytes_required > data_->size_bytes) {
+      NANOARROW_RETURN_NOT_OK(
+          ArrowBufferAppendFill(data_, 0, bytes_required - data_->size_bytes));
+    }
+
+    if (ReadUnsafe<int8_t>(data)) {
+      ArrowBitSet(data_->data, array->length);
+    } else {
+      ArrowBitClear(data_->data, array->length);
+    }
+
+    return AppendValid(array);
+  }
+};
+
+// Reader for Pg->Arrow conversions whose representations are identical minus
+// the bswap from network endian. This includes all integral and float types.
+template <typename T, T kOffset = 0>
+class PostgresCopyNetworkEndianFieldReader : public PostgresCopyFieldReader {
+ public:
+  ArrowErrorCode Read(ArrowBufferView* data, int32_t field_size_bytes, ArrowArray* array,
+                      ArrowError* error) override {
+    if (field_size_bytes <= 0) {
+      return ArrowArrayAppendNull(array, 1);
+    }
+
+    if (field_size_bytes != static_cast<int32_t>(sizeof(T))) {
+      ArrowErrorSet(error, "Expected field with %d bytes but found field with %d bytes",
+                    static_cast<int>(sizeof(T)),
+                    static_cast<int>(field_size_bytes));  // NOLINT(runtime/int)
+      return EINVAL;
+    }
+
+    T value = kOffset + ReadUnsafe<T>(data);
+    NANOARROW_RETURN_NOT_OK(ArrowBufferAppend(data_, &value, sizeof(T)));
+    return AppendValid(array);
+  }
+};
+
+// Reader for Intervals
+class PostgresCopyIntervalFieldReader : public PostgresCopyFieldReader {
+ public:
+  ArrowErrorCode Read(ArrowBufferView* data, int32_t field_size_bytes, ArrowArray* array,
+                      ArrowError* error) override {
+    if (field_size_bytes <= 0) {
+      return ArrowArrayAppendNull(array, 1);
+    }
+
+    if (field_size_bytes != 16) {
+      ArrowErrorSet(error, "Expected field with %d bytes but found field with %d bytes",
+                    16,
+                    static_cast<int>(field_size_bytes));  // NOLINT(runtime/int)
+      return EINVAL;
+    }
+
+    // postgres stores time as usec, arrow stores as ns
+    const int64_t time_usec = ReadUnsafe<int64_t>(data);
+    int64_t time;
+
+    if (time_usec > kMaxSafeMicrosToNanos || time_usec < kMinSafeMicrosToNanos) {
+      ArrowErrorSet(error,
+                    "[libpq] Interval with time value %" PRId64
+                    " usec would overflow when converting to nanoseconds",
+                    time_usec);
+      return EINVAL;
+    }
+
+    time = time_usec * 1000;
+
+    const int32_t days = ReadUnsafe<int32_t>(data);
+    const int32_t months = ReadUnsafe<int32_t>(data);
+
+    NANOARROW_RETURN_NOT_OK(ArrowBufferAppend(data_, &months, sizeof(int32_t)));
+    NANOARROW_RETURN_NOT_OK(ArrowBufferAppend(data_, &days, sizeof(int32_t)));
+    NANOARROW_RETURN_NOT_OK(ArrowBufferAppend(data_, &time, sizeof(int64_t)));
+    return AppendValid(array);
+  }
+};
+
+// // Converts COPY resulting from the Postgres NUMERIC type into a string.
+// Rewritten based on the Postgres implementation of NUMERIC cast to string in
+// src/backend/utils/adt/numeric.c : get_str_from_var() (Note that in the initial source,
+// DEC_DIGITS is always 4 and DBASE is always 10000).
+//
+// Briefly, the Postgres representation of "numeric" is an array of int16_t ("digits")
+// from most significant to least significant. Each "digit" is a value between 0000 and
+// 9999. There are weight + 1 digits before the decimal point and dscale digits after the
+// decimal point. Both of those values can be zero or negative. A "sign" component
+// encodes the positive or negativeness of the value and is also used to encode special
+// values (inf, -inf, and nan).
+class PostgresCopyNumericFieldReader : public PostgresCopyFieldReader {
+ public:
+  ArrowErrorCode Read(ArrowBufferView* data, int32_t field_size_bytes, ArrowArray* array,
+                      ArrowError* error) override {
+    // -1 for NULL
+    if (field_size_bytes < 0) {
+      return ArrowArrayAppendNull(array, 1);
+    }
+
+    // Read the input
+    if (data->size_bytes < static_cast<int64_t>(4 * sizeof(int16_t))) {
+      ArrowErrorSet(error,
+                    "Expected at least %d bytes of field data for numeric copy data but "
+                    "only %d bytes of input remain",
+                    static_cast<int>(4 * sizeof(int16_t)),
+                    static_cast<int>(data->size_bytes));  // NOLINT(runtime/int)
+      return EINVAL;
+    }
+
+    int16_t ndigits = ReadUnsafe<int16_t>(data);
+    int16_t weight = ReadUnsafe<int16_t>(data);
+    uint16_t sign = ReadUnsafe<uint16_t>(data);
+    uint16_t dscale = ReadUnsafe<uint16_t>(data);
+
+    if (data->size_bytes < static_cast<int64_t>(ndigits * sizeof(int16_t))) {
+      ArrowErrorSet(error,
+                    "Expected at least %d bytes of field data for numeric digits copy "
+                    "data but only %d bytes of input remain",
+                    static_cast<int>(ndigits * sizeof(int16_t)),
+                    static_cast<int>(data->size_bytes));  // NOLINT(runtime/int)
+      return EINVAL;
+    }
+
+    digits_.clear();
+    for (int16_t i = 0; i < ndigits; i++) {
+      digits_.push_back(ReadUnsafe<int16_t>(data));
+    }
+
+    // Handle special values
+    std::string special_value;
+    switch (sign) {
+      case kNumericNAN:
+        special_value = std::string("nan");
+        break;
+      case kNumericPinf:
+        special_value = std::string("inf");
+        break;
+      case kNumericNinf:
+        special_value = std::string("-inf");
+        break;
+      case kNumericPos:
+      case kNumericNeg:
+        special_value = std::string("");
+        break;
+      default:
+        ArrowErrorSet(error,
+                      "Unexpected value for sign read from Postgres numeric field: %d",
+                      static_cast<int>(sign));
+        return EINVAL;
+    }
+
+    if (!special_value.empty()) {
+      NANOARROW_RETURN_NOT_OK(
+          ArrowBufferAppend(data_, special_value.data(), special_value.size()));
+      NANOARROW_RETURN_NOT_OK(ArrowBufferAppendInt32(offsets_, data_->size_bytes));
+      return AppendValid(array);
+    }
+
+    // Calculate string space requirement
+    int64_t max_chars_required = std::max<int64_t>(1, (weight + 1) * kDecDigits);
+    max_chars_required += dscale + kDecDigits + 2;
+    NANOARROW_RETURN_NOT_OK(ArrowBufferReserve(data_, max_chars_required));
+    char* out0 = reinterpret_cast<char*>(data_->data + data_->size_bytes);
+    char* out = out0;
+
+    // Build output string in-place, starting with the negative sign
+    if (sign == kNumericNeg) {
+      *out++ = '-';
+    }
+
+    // ...then digits before the decimal point
+    int d;
+    int d1;
+    int16_t dig;
+
+    if (weight < 0) {
+      d = weight + 1;
+      *out++ = '0';
+    } else {
+      for (d = 0; d <= weight; d++) {
+        if (d < ndigits) {
+          dig = digits_[d];
+        } else {
+          dig = 0;
+        }
+
+        // To strip leading zeroes
+        int append = (d > 0);
+
+        for (const auto pow10 : {1000, 100, 10, 1}) {
+          d1 = dig / pow10;
+          dig -= d1 * pow10;
+          append |= (d1 > 0);
+          if (append) {
+            *out++ = d1 + '0';
+          }
+        }
+      }
+    }
+
+    // ...then the decimal point + digits after it. This may write more digits
+    // than specified by dscale so we need to keep track of how many we want to
+    // keep here.
+    int64_t actual_chars_required = out - out0;
+
+    if (dscale > 0) {
+      *out++ = '.';
+      actual_chars_required += dscale + 1;
+
+      for (int i = 0; i < dscale; i++, d++, i += kDecDigits) {
+        if (d >= 0 && d < ndigits) {
+          dig = digits_[d];
+        } else {
+          dig = 0;
+        }
+
+        for (const auto pow10 : {1000, 100, 10, 1}) {
+          d1 = dig / pow10;
+          dig -= d1 * pow10;
+          *out++ = d1 + '0';
+        }
+      }
+    }
+
+    // Update data buffer size and add offsets
+    data_->size_bytes += actual_chars_required;
+    NANOARROW_RETURN_NOT_OK(ArrowBufferAppendInt32(offsets_, data_->size_bytes));
+    return AppendValid(array);
+  }
+
+ private:
+  std::vector<int16_t> digits_;
+
+  // Number of decimal digits per Postgres digit
+  static const int kDecDigits = 4;
+  // The "base" of the Postgres representation (i.e., each "digit" is 0 to 9999)
+  static const int kNBase = 10000;
+  // Valid values for the sign component
+  static const uint16_t kNumericPos = 0x0000;
+  static const uint16_t kNumericNeg = 0x4000;
+  static const uint16_t kNumericNAN = 0xC000;
+  static const uint16_t kNumericPinf = 0xD000;
+  static const uint16_t kNumericNinf = 0xF000;
+};
+
+// Reader for Pg->Arrow conversions whose Arrow representation is simply the
+// bytes of the field representation. This can be used with binary and string
+// Arrow types and any Postgres type.
+class PostgresCopyBinaryFieldReader : public PostgresCopyFieldReader {
+ public:
+  ArrowErrorCode Read(ArrowBufferView* data, int32_t field_size_bytes, ArrowArray* array,
+                      ArrowError* error) override {
+    // -1 for NULL (0 would be empty string)
+    if (field_size_bytes < 0) {
+      return ArrowArrayAppendNull(array, 1);
+    }
+
+    if (field_size_bytes > data->size_bytes) {
+      ArrowErrorSet(error, "Expected %d bytes of field data but got %d bytes of input",
+                    static_cast<int>(field_size_bytes),
+                    static_cast<int>(data->size_bytes));  // NOLINT(runtime/int)
+      return EINVAL;
+    }
+
+    NANOARROW_RETURN_NOT_OK(ArrowBufferAppend(data_, data->data.data, field_size_bytes));
+    data->data.as_uint8 += field_size_bytes;
+    data->size_bytes -= field_size_bytes;
+
+    int32_t* offsets = reinterpret_cast<int32_t*>(offsets_->data);
+    NANOARROW_RETURN_NOT_OK(
+        ArrowBufferAppendInt32(offsets_, offsets[array->length] + field_size_bytes));
+
+    return AppendValid(array);
+  }
+};
+
+class PostgresCopyArrayFieldReader : public PostgresCopyFieldReader {
+ public:
+  void InitChild(std::unique_ptr<PostgresCopyFieldReader> child) {
+    child_ = std::move(child);
+    child_->Init(pg_type_.child(0));
+  }
+
+  ArrowErrorCode InitSchema(ArrowSchema* schema) override {
+    NANOARROW_RETURN_NOT_OK(PostgresCopyFieldReader::InitSchema(schema));
+    NANOARROW_RETURN_NOT_OK(child_->InitSchema(schema->children[0]));
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode InitArray(ArrowArray* array) override {
+    NANOARROW_RETURN_NOT_OK(PostgresCopyFieldReader::InitArray(array));
+    NANOARROW_RETURN_NOT_OK(child_->InitArray(array->children[0]));
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode Read(ArrowBufferView* data, int32_t field_size_bytes, ArrowArray* array,
+                      ArrowError* error) override {
+    if (field_size_bytes <= 0) {
+      return ArrowArrayAppendNull(array, 1);
+    }
+
+    // Keep the cursor where we start to parse the array so we can check
+    // the number of bytes read against the field size when finished
+    const uint8_t* data0 = data->data.as_uint8;
+
+    int32_t n_dim;
+    NANOARROW_RETURN_NOT_OK(ReadChecked<int32_t>(data, &n_dim, error));
+    int32_t flags;
+    NANOARROW_RETURN_NOT_OK(ReadChecked<int32_t>(data, &flags, error));
+    uint32_t element_type_oid;
+    NANOARROW_RETURN_NOT_OK(ReadChecked<uint32_t>(data, &element_type_oid, error));
+
+    // We could validate the OID here, but this is a poor fit for all cases
+    // (e.g. testing) since the OID can be specific to each database
+
+    if (n_dim < 0) {
+      ArrowErrorSet(error, "Expected array n_dim > 0 but got %d",
+                    static_cast<int>(n_dim));  // NOLINT(runtime/int)
+      return EINVAL;
+    }
+
+    // This is apparently allowed
+    if (n_dim == 0) {
+      NANOARROW_RETURN_NOT_OK(ArrowArrayFinishElement(array));
+      return NANOARROW_OK;
+    }
+
+    int64_t n_items = 1;
+    for (int32_t i = 0; i < n_dim; i++) {
+      int32_t dim_size;
+      NANOARROW_RETURN_NOT_OK(ReadChecked<int32_t>(data, &dim_size, error));
+      n_items *= dim_size;
+
+      int32_t lower_bound;
+      NANOARROW_RETURN_NOT_OK(ReadChecked<int32_t>(data, &lower_bound, error));
+      if (lower_bound != 1) {
+        ArrowErrorSet(error, "Array value with lower bound != 1 is not supported");
+        return EINVAL;
+      }
+    }
+
+    for (int64_t i = 0; i < n_items; i++) {
+      int32_t child_field_size_bytes;
+      NANOARROW_RETURN_NOT_OK(ReadChecked<int32_t>(data, &child_field_size_bytes, error));
+      NANOARROW_RETURN_NOT_OK(
+          child_->Read(data, child_field_size_bytes, array->children[0], error));
+    }
+
+    int64_t bytes_read = data->data.as_uint8 - data0;
+    if (bytes_read != field_size_bytes) {
+      ArrowErrorSet(error, "Expected to read %d bytes from array field but read %d bytes",
+                    static_cast<int>(field_size_bytes),
+                    static_cast<int>(bytes_read));  // NOLINT(runtime/int)
+      return EINVAL;
+    }
+
+    NANOARROW_RETURN_NOT_OK(ArrowArrayFinishElement(array));
+    return NANOARROW_OK;
+  }
+
+ private:
+  std::unique_ptr<PostgresCopyFieldReader> child_;
+};
+
+class PostgresCopyRecordFieldReader : public PostgresCopyFieldReader {
+ public:
+  void AppendChild(std::unique_ptr<PostgresCopyFieldReader> child) {
+    int64_t child_i = static_cast<int64_t>(children_.size());
+    children_.push_back(std::move(child));
+    children_[child_i]->Init(pg_type_.child(child_i));
+  }
+
+  ArrowErrorCode InitSchema(ArrowSchema* schema) override {
+    NANOARROW_RETURN_NOT_OK(PostgresCopyFieldReader::InitSchema(schema));
+    for (int64_t i = 0; i < schema->n_children; i++) {
+      NANOARROW_RETURN_NOT_OK(children_[i]->InitSchema(schema->children[i]));
+    }
+
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode InitArray(ArrowArray* array) override {
+    NANOARROW_RETURN_NOT_OK(PostgresCopyFieldReader::InitArray(array));
+    for (int64_t i = 0; i < array->n_children; i++) {
+      NANOARROW_RETURN_NOT_OK(children_[i]->InitArray(array->children[i]));
+    }
+
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode Read(ArrowBufferView* data, int32_t field_size_bytes, ArrowArray* array,
+                      ArrowError* error) override {
+    if (field_size_bytes < 0) {
+      return ArrowArrayAppendNull(array, 1);
+    }
+
+    // Keep the cursor where we start to parse the field so we can check
+    // the number of bytes read against the field size when finished
+    const uint8_t* data0 = data->data.as_uint8;
+
+    int32_t n_fields;
+    NANOARROW_RETURN_NOT_OK(ReadChecked<int32_t>(data, &n_fields, error));
+    if (n_fields != array->n_children) {
+      ArrowErrorSet(error, "Expected nested record type to have %ld fields but got %d",
+                    static_cast<long>(array->n_children),  // NOLINT(runtime/int)
+                    static_cast<int>(n_fields));           // NOLINT(runtime/int)
+      return EINVAL;
+    }
+
+    for (int32_t i = 0; i < n_fields; i++) {
+      uint32_t child_oid;
+      NANOARROW_RETURN_NOT_OK(ReadChecked<uint32_t>(data, &child_oid, error));
+
+      int32_t child_field_size_bytes;
+      NANOARROW_RETURN_NOT_OK(ReadChecked<int32_t>(data, &child_field_size_bytes, error));
+      int result =
+          children_[i]->Read(data, child_field_size_bytes, array->children[i], error);
+
+      // On overflow, pretend all previous children for this struct were never
+      // appended to. This leaves array in a valid state in the specific case
+      // where EOVERFLOW was returned so that a higher level caller can attempt
+      // to try again after creating a new array.
+      if (result == EOVERFLOW) {
+        for (int16_t j = 0; j < i; j++) {
+          array->children[j]->length--;
+        }
+      }
+
+      if (result != NANOARROW_OK) {
+        return result;
+      }
+    }
+
+    // field size == -1 means don't check (e.g., for a top-level row tuple)
+    int64_t bytes_read = data->data.as_uint8 - data0;
+    if (field_size_bytes != -1 && bytes_read != field_size_bytes) {
+      ArrowErrorSet(error,
+                    "Expected to read %d bytes from record field but read %d bytes",
+                    static_cast<int>(field_size_bytes),
+                    static_cast<int>(bytes_read));  // NOLINT(runtime/int)
+      return EINVAL;
+    }
+
+    array->length++;
+    return NANOARROW_OK;
+  }
+
+ private:
+  std::vector<std::unique_ptr<PostgresCopyFieldReader>> children_;
+};
+
+// Subtely different from a Record field item: field count is an int16_t
+// instead of an int32_t and each field is not prefixed by its OID.
+class PostgresCopyFieldTupleReader : public PostgresCopyFieldReader {
+ public:
+  void AppendChild(std::unique_ptr<PostgresCopyFieldReader> child) {
+    int64_t child_i = static_cast<int64_t>(children_.size());
+    children_.push_back(std::move(child));
+    children_[child_i]->Init(pg_type_.child(child_i));
+  }
+
+  ArrowErrorCode InitSchema(ArrowSchema* schema) override {
+    NANOARROW_RETURN_NOT_OK(PostgresCopyFieldReader::InitSchema(schema));
+    for (int64_t i = 0; i < schema->n_children; i++) {
+      NANOARROW_RETURN_NOT_OK(children_[i]->InitSchema(schema->children[i]));
+    }
+
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode InitArray(ArrowArray* array) override {
+    NANOARROW_RETURN_NOT_OK(PostgresCopyFieldReader::InitArray(array));
+    for (int64_t i = 0; i < array->n_children; i++) {
+      NANOARROW_RETURN_NOT_OK(children_[i]->InitArray(array->children[i]));
+    }
+
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode Read(ArrowBufferView* data, int32_t field_size_bytes, ArrowArray* array,
+                      ArrowError* error) override {
+    int16_t n_fields;
+    NANOARROW_RETURN_NOT_OK(ReadChecked<int16_t>(data, &n_fields, error));
+    if (n_fields == -1) {
+      return ENODATA;
+    } else if (n_fields != array->n_children) {
+      ArrowErrorSet(error,
+                    "Expected -1 for end-of-stream or number of fields in output array "
+                    "(%ld) but got %d",
+                    static_cast<long>(array->n_children),  // NOLINT(runtime/int)
+                    static_cast<int>(n_fields));           // NOLINT(runtime/int)
+      return EINVAL;
+    }
+
+    for (int16_t i = 0; i < n_fields; i++) {
+      int32_t child_field_size_bytes;
+      NANOARROW_RETURN_NOT_OK(ReadChecked<int32_t>(data, &child_field_size_bytes, error));
+      int result =
+          children_[i]->Read(data, child_field_size_bytes, array->children[i], error);
+
+      // On overflow, pretend all previous children for this struct were never
+      // appended to. This leaves array in a valid state in the specific case
+      // where EOVERFLOW was returned so that a higher level caller can attempt
+      // to try again after creating a new array.
+      if (result == EOVERFLOW) {
+        for (int16_t j = 0; j < i; j++) {
+          array->children[j]->length--;
+        }
+      }
+
+      if (result != NANOARROW_OK) {
+        return result;
+      }
+    }
+
+    array->length++;
+    return NANOARROW_OK;
+  }
+
+ private:
+  std::vector<std::unique_ptr<PostgresCopyFieldReader>> children_;
+};
+
+// Factory for a PostgresCopyFieldReader that instantiates the proper subclass
+// and gives a nice error for Postgres type -> Arrow type conversions that aren't
+// supported.
+static inline ArrowErrorCode ErrorCantConvert(ArrowError* error,
+                                              const PostgresType& pg_type,
+                                              const ArrowSchemaView& schema_view) {
+  ArrowErrorSet(error, "Can't convert Postgres type '%s' to Arrow type '%s'",
+                pg_type.typname().c_str(),
+                ArrowTypeString(schema_view.type));  // NOLINT(runtime/int)
+  return EINVAL;
+}
+
+static inline ArrowErrorCode MakeCopyFieldReader(const PostgresType& pg_type,
+                                                 ArrowSchema* schema,
+                                                 PostgresCopyFieldReader** out,
+                                                 ArrowError* error) {
+  ArrowSchemaView schema_view;
+  NANOARROW_RETURN_NOT_OK(ArrowSchemaViewInit(&schema_view, schema, nullptr));
+
+  switch (schema_view.type) {
+    case NANOARROW_TYPE_BOOL:
+      switch (pg_type.type_id()) {
+        case PostgresTypeId::kBool:
+          *out = new PostgresCopyBooleanFieldReader();
+          return NANOARROW_OK;
+        default:
+          return ErrorCantConvert(error, pg_type, schema_view);
+      }
+
+    case NANOARROW_TYPE_INT16:
+      switch (pg_type.type_id()) {
+        case PostgresTypeId::kInt2:
+          *out = new PostgresCopyNetworkEndianFieldReader<int16_t>();
+          return NANOARROW_OK;
+        default:
+          return ErrorCantConvert(error, pg_type, schema_view);
+      }
+
+    case NANOARROW_TYPE_INT32:
+      switch (pg_type.type_id()) {
+        case PostgresTypeId::kInt4:
+        case PostgresTypeId::kOid:
+        case PostgresTypeId::kRegproc:
+          *out = new PostgresCopyNetworkEndianFieldReader<int32_t>();
+          return NANOARROW_OK;
+        default:
+          return ErrorCantConvert(error, pg_type, schema_view);
+      }
+
+    case NANOARROW_TYPE_INT64:
+      switch (pg_type.type_id()) {
+        case PostgresTypeId::kInt8:
+          *out = new PostgresCopyNetworkEndianFieldReader<int64_t>();
+          return NANOARROW_OK;
+        default:
+          return ErrorCantConvert(error, pg_type, schema_view);
+      }
+
+    case NANOARROW_TYPE_FLOAT:
+      switch (pg_type.type_id()) {
+        case PostgresTypeId::kFloat4:
+          *out = new PostgresCopyNetworkEndianFieldReader<uint32_t>();
+          return NANOARROW_OK;
+        default:
+          return ErrorCantConvert(error, pg_type, schema_view);
+      }
+
+    case NANOARROW_TYPE_DOUBLE:
+      switch (pg_type.type_id()) {
+        case PostgresTypeId::kFloat8:
+          *out = new PostgresCopyNetworkEndianFieldReader<uint64_t>();
+          return NANOARROW_OK;
+        default:
+          return ErrorCantConvert(error, pg_type, schema_view);
+      }
+
+    case NANOARROW_TYPE_STRING:
+      switch (pg_type.type_id()) {
+        case PostgresTypeId::kChar:
+        case PostgresTypeId::kVarchar:
+        case PostgresTypeId::kText:
+        case PostgresTypeId::kBpchar:
+        case PostgresTypeId::kName:
+          *out = new PostgresCopyBinaryFieldReader();
+          return NANOARROW_OK;
+        case PostgresTypeId::kNumeric:
+          *out = new PostgresCopyNumericFieldReader();
+          return NANOARROW_OK;
+        default:
+          return ErrorCantConvert(error, pg_type, schema_view);
+      }
+
+    case NANOARROW_TYPE_BINARY:
+      // No need to check pg_type here: we can return the bytes of any
+      // Postgres type as binary.
+      *out = new PostgresCopyBinaryFieldReader();
+      return NANOARROW_OK;
+
+    case NANOARROW_TYPE_LIST:
+      switch (pg_type.type_id()) {
+        case PostgresTypeId::kArray: {
+          if (pg_type.n_children() != 1) {
+            ArrowErrorSet(
+                error, "Expected Postgres array type to have one child but found %ld",
+                static_cast<long>(pg_type.n_children()));  // NOLINT(runtime/int)
+            return EINVAL;
+          }
+
+          auto array_reader = std::unique_ptr<PostgresCopyArrayFieldReader>(
+              new PostgresCopyArrayFieldReader());
+          array_reader->Init(pg_type);
+
+          PostgresCopyFieldReader* child_reader;
+          NANOARROW_RETURN_NOT_OK(MakeCopyFieldReader(
+              pg_type.child(0), schema->children[0], &child_reader, error));
+          array_reader->InitChild(std::unique_ptr<PostgresCopyFieldReader>(child_reader));
+
+          *out = array_reader.release();
+          return NANOARROW_OK;
+        }
+        default:
+          return ErrorCantConvert(error, pg_type, schema_view);
+      }
+
+    case NANOARROW_TYPE_STRUCT:
+      switch (pg_type.type_id()) {
+        case PostgresTypeId::kRecord: {
+          if (pg_type.n_children() != schema->n_children) {
+            ArrowErrorSet(error,
+                          "Can't convert Postgres record type with %ld chlidren to Arrow "
+                          "struct type with %ld children",
+                          static_cast<long>(pg_type.n_children()),  // NOLINT(runtime/int)
+                          static_cast<long>(schema->n_children));   // NOLINT(runtime/int)
+            return EINVAL;
+          }
+
+          auto record_reader = std::unique_ptr<PostgresCopyRecordFieldReader>(
+              new PostgresCopyRecordFieldReader());
+          record_reader->Init(pg_type);
+
+          for (int64_t i = 0; i < pg_type.n_children(); i++) {
+            PostgresCopyFieldReader* child_reader;
+            NANOARROW_RETURN_NOT_OK(MakeCopyFieldReader(
+                pg_type.child(i), schema->children[i], &child_reader, error));
+            record_reader->AppendChild(
+                std::unique_ptr<PostgresCopyFieldReader>(child_reader));
+          }
+
+          *out = record_reader.release();
+          return NANOARROW_OK;
+        }
+        default:
+          return ErrorCantConvert(error, pg_type, schema_view);
+      }
+
+    case NANOARROW_TYPE_DATE32: {
+      // 2000-01-01
+      constexpr int32_t kPostgresDateEpoch = 10957;
+      *out = new PostgresCopyNetworkEndianFieldReader<int32_t, kPostgresDateEpoch>();
+      return NANOARROW_OK;
+    }
+
+    case NANOARROW_TYPE_TIME64: {
+      *out = new PostgresCopyNetworkEndianFieldReader<int64_t>();
+      return NANOARROW_OK;
+    }
+
+    case NANOARROW_TYPE_TIMESTAMP:
+      switch (pg_type.type_id()) {
+        case PostgresTypeId::kTimestamp:
+        case PostgresTypeId::kTimestamptz: {
+          // 2000-01-01 00:00:00.000000 in microseconds
+          constexpr int64_t kPostgresTimestampEpoch = 946684800000000;
+          *out = new PostgresCopyNetworkEndianFieldReader<int64_t,
+                                                          kPostgresTimestampEpoch>();
+          return NANOARROW_OK;
+        }
+        default:
+          return ErrorCantConvert(error, pg_type, schema_view);
+      }
+    case NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO:
+      switch (pg_type.type_id()) {
+        case PostgresTypeId::kInterval: {
+          *out = new PostgresCopyIntervalFieldReader();
+          return NANOARROW_OK;
+        }
+        default:
+          return ErrorCantConvert(error, pg_type, schema_view);
+      }
+
+    default:
+      return ErrorCantConvert(error, pg_type, schema_view);
+  }
+}
+
+class PostgresCopyStreamReader {
+ public:
+  ArrowErrorCode Init(PostgresType pg_type) {
+    if (pg_type.type_id() != PostgresTypeId::kRecord) {
+      return EINVAL;
+    }
+
+    pg_type_ = std::move(pg_type);
+    root_reader_.Init(pg_type_);
+    array_size_approx_bytes_ = 0;
+    return NANOARROW_OK;
+  }
+
+  int64_t array_size_approx_bytes() const { return array_size_approx_bytes_; }
+
+  ArrowErrorCode SetOutputSchema(ArrowSchema* schema, ArrowError* error) {
+    if (std::string(schema_->format) != "+s") {
+      ArrowErrorSet(
+          error,
+          "Expected output schema of type struct but got output schema with format '%s'",
+          schema_->format);  // NOLINT(runtime/int)
+      return EINVAL;
+    }
+
+    if (schema_->n_children != root_reader_.InputType().n_children()) {
+      ArrowErrorSet(error,
+                    "Expected output schema with %ld columns to match Postgres input but "
+                    "got schema with %ld columns",
+                    static_cast<long>(  // NOLINT(runtime/int)
+                        root_reader_.InputType().n_children()),
+                    static_cast<long>(schema->n_children));  // NOLINT(runtime/int)
+      return EINVAL;
+    }
+
+    schema_.reset(schema);
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode InferOutputSchema(ArrowError* error) {
+    schema_.reset();
+    ArrowSchemaInit(schema_.get());
+    NANOARROW_RETURN_NOT_OK(root_reader_.InputType().SetSchema(schema_.get()));
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode InitFieldReaders(ArrowError* error) {
+    if (schema_->release == nullptr) {
+      return EINVAL;
+    }
+
+    const PostgresType& root_type = root_reader_.InputType();
+
+    for (int64_t i = 0; i < root_type.n_children(); i++) {
+      const PostgresType& child_type = root_type.child(i);
+      PostgresCopyFieldReader* child_reader;
+      NANOARROW_RETURN_NOT_OK(
+          MakeCopyFieldReader(child_type, schema_->children[i], &child_reader, error));
+      root_reader_.AppendChild(std::unique_ptr<PostgresCopyFieldReader>(child_reader));
+    }
+
+    NANOARROW_RETURN_NOT_OK(root_reader_.InitSchema(schema_.get()));
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode ReadHeader(ArrowBufferView* data, ArrowError* error) {
+    if (data->size_bytes < static_cast<int64_t>(sizeof(kPgCopyBinarySignature))) {
+      ArrowErrorSet(
+          error,
+          "Expected PGCOPY signature of %ld bytes at beginning of stream but "
+          "found %ld bytes of input",
+          static_cast<long>(sizeof(kPgCopyBinarySignature)),  // NOLINT(runtime/int)
+          static_cast<long>(data->size_bytes));               // NOLINT(runtime/int)
+      return EINVAL;
+    }
+
+    if (memcmp(data->data.data, kPgCopyBinarySignature, sizeof(kPgCopyBinarySignature)) !=
+        0) {
+      ArrowErrorSet(error, "Invalid PGCOPY signature at beginning of stream");
+      return EINVAL;
+    }
+
+    data->data.as_uint8 += sizeof(kPgCopyBinarySignature);
+    data->size_bytes -= sizeof(kPgCopyBinarySignature);
+
+    uint32_t flags;
+    NANOARROW_RETURN_NOT_OK(ReadChecked<uint32_t>(data, &flags, error));
+    uint32_t extension_length;
+    NANOARROW_RETURN_NOT_OK(ReadChecked<uint32_t>(data, &extension_length, error));
+
+    if (data->size_bytes < static_cast<int64_t>(extension_length)) {
+      ArrowErrorSet(error,
+                    "Expected %ld bytes of extension metadata at start of stream but "
+                    "found %ld bytes of input",
+                    static_cast<long>(extension_length),   // NOLINT(runtime/int)
+                    static_cast<long>(data->size_bytes));  // NOLINT(runtime/int)
+      return EINVAL;
+    }
+
+    data->data.as_uint8 += extension_length;
+    data->size_bytes -= extension_length;
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode ReadRecord(ArrowBufferView* data, ArrowError* error) {
+    if (array_->release == nullptr) {
+      NANOARROW_RETURN_NOT_OK(
+          ArrowArrayInitFromSchema(array_.get(), schema_.get(), error));
+      NANOARROW_RETURN_NOT_OK(ArrowArrayStartAppending(array_.get()));
+      NANOARROW_RETURN_NOT_OK(root_reader_.InitArray(array_.get()));
+      array_size_approx_bytes_ = 0;
+    }
+
+    const uint8_t* start = data->data.as_uint8;
+    NANOARROW_RETURN_NOT_OK(root_reader_.Read(data, -1, array_.get(), error));
+    array_size_approx_bytes_ += (data->data.as_uint8 - start);
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode GetSchema(ArrowSchema* out) {
+    return ArrowSchemaDeepCopy(schema_.get(), out);
+  }
+
+  ArrowErrorCode GetArray(ArrowArray* out, ArrowError* error) {
+    if (array_->release == nullptr) {
+      return EINVAL;
+    }
+
+    NANOARROW_RETURN_NOT_OK(ArrowArrayFinishBuildingDefault(array_.get(), error));
+    ArrowArrayMove(array_.get(), out);
+    return NANOARROW_OK;
+  }
+
+  const PostgresType& pg_type() const { return pg_type_; }
+
+ private:
+  PostgresType pg_type_;
+  PostgresCopyFieldTupleReader root_reader_;
+  nanoarrow::UniqueSchema schema_;
+  nanoarrow::UniqueArray array_;
+  int64_t array_size_approx_bytes_;
+};
+
+class PostgresCopyFieldWriter {
+ public:
+  virtual ~PostgresCopyFieldWriter() {}
+
+  void Init(struct ArrowArrayView* array_view) { array_view_ = array_view; };
+
+  virtual ArrowErrorCode Write(ArrowBuffer* buffer, int64_t index, ArrowError* error) {
+    return ENOTSUP;
+  }
+
+ protected:
+  struct ArrowArrayView* array_view_;
+  std::vector<std::unique_ptr<PostgresCopyFieldWriter>> children_;
+};
+
+class PostgresCopyFieldTupleWriter : public PostgresCopyFieldWriter {
+ public:
+  void AppendChild(std::unique_ptr<PostgresCopyFieldWriter> child) {
+    int64_t child_i = static_cast<int64_t>(children_.size());
+    children_.push_back(std::move(child));
+    children_[child_i]->Init(array_view_->children[child_i]);
+  }
+
+  ArrowErrorCode Write(ArrowBuffer* buffer, int64_t index, ArrowError* error) override {
+    if (index >= array_view_->length) {
+      return ENODATA;
+    }
+
+    const int16_t n_fields = children_.size();
+    NANOARROW_RETURN_NOT_OK(WriteChecked<int16_t>(buffer, n_fields, error));
+
+    for (int16_t i = 0; i < n_fields; i++) {
+      const int8_t is_null = ArrowArrayViewIsNull(array_view_->children[i], index);
+      if (is_null) {
+        constexpr int32_t field_size_bytes = -1;
+        NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, field_size_bytes, error));
+      } else {
+        children_[i]->Write(buffer, index, error);
+      }
+    }
+
+    return NANOARROW_OK;
+  }
+
+ private:
+  std::vector<std::unique_ptr<PostgresCopyFieldWriter>> children_;
+};
+
+class PostgresCopyBooleanFieldWriter : public PostgresCopyFieldWriter {
+ public:
+  ArrowErrorCode Write(ArrowBuffer* buffer, int64_t index, ArrowError* error) override {
+    constexpr int32_t field_size_bytes = 1;
+    NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, field_size_bytes, error));
+    const int8_t value =
+        static_cast<int8_t>(ArrowArrayViewGetIntUnsafe(array_view_, index));
+    NANOARROW_RETURN_NOT_OK(WriteChecked<int8_t>(buffer, value, error));
+
+    return ADBC_STATUS_OK;
+  }
+};
+
+template <typename T, T kOffset = 0>
+class PostgresCopyNetworkEndianFieldWriter : public PostgresCopyFieldWriter {
+ public:
+  ArrowErrorCode Write(ArrowBuffer* buffer, int64_t index, ArrowError* error) override {
+    constexpr int32_t field_size_bytes = sizeof(T);
+    NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, field_size_bytes, error));
+    const T value =
+        static_cast<T>(ArrowArrayViewGetIntUnsafe(array_view_, index)) - kOffset;
+    NANOARROW_RETURN_NOT_OK(WriteChecked<T>(buffer, value, error));
+
+    return ADBC_STATUS_OK;
+  }
+};
+
+class PostgresCopyFloatFieldWriter : public PostgresCopyFieldWriter {
+ public:
+  ArrowErrorCode Write(ArrowBuffer* buffer, int64_t index, ArrowError* error) override {
+    constexpr int32_t field_size_bytes = sizeof(uint32_t);
+    NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, field_size_bytes, error));
+
+    uint32_t value;
+    float raw_value = ArrowArrayViewGetDoubleUnsafe(array_view_, index);
+    std::memcpy(&value, &raw_value, sizeof(uint32_t));
+    NANOARROW_RETURN_NOT_OK(WriteChecked<uint32_t>(buffer, value, error));
+
+    return ADBC_STATUS_OK;
+  }
+};
+
+class PostgresCopyDoubleFieldWriter : public PostgresCopyFieldWriter {
+ public:
+  ArrowErrorCode Write(ArrowBuffer* buffer, int64_t index, ArrowError* error) override {
+    constexpr int32_t field_size_bytes = sizeof(uint64_t);
+    NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, field_size_bytes, error));
+
+    uint64_t value;
+    double raw_value = ArrowArrayViewGetDoubleUnsafe(array_view_, index);
+    std::memcpy(&value, &raw_value, sizeof(uint64_t));
+    NANOARROW_RETURN_NOT_OK(WriteChecked<uint64_t>(buffer, value, error));
+
+    return ADBC_STATUS_OK;
+  }
+};
+
+class PostgresCopyIntervalFieldWriter : public PostgresCopyFieldWriter {
+ public:
+  ArrowErrorCode Write(ArrowBuffer* buffer, int64_t index, ArrowError* error) override {
+    constexpr int32_t field_size_bytes = 16;
+    NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, field_size_bytes, error));
+
+    struct ArrowInterval interval;
+    ArrowIntervalInit(&interval, NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO);
+    ArrowArrayViewGetIntervalUnsafe(array_view_, index, &interval);
+    const int64_t ms = interval.ns / 1000;
+    NANOARROW_RETURN_NOT_OK(WriteChecked<int64_t>(buffer, ms, error));
+    NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, interval.days, error));
+    NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, interval.months, error));
+
+    return ADBC_STATUS_OK;
+  }
+};
+
+template <enum ArrowTimeUnit TU>
+class PostgresCopyDurationFieldWriter : public PostgresCopyFieldWriter {
+ public:
+  ArrowErrorCode Write(ArrowBuffer* buffer, int64_t index, ArrowError* error) override {
+    constexpr int32_t field_size_bytes = 16;
+    NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, field_size_bytes, error));
+
+    int64_t raw_value = ArrowArrayViewGetIntUnsafe(array_view_, index);
+    int64_t value;
+
+    bool overflow_safe = true;
+    switch (TU) {
+      case NANOARROW_TIME_UNIT_SECOND:
+        if ((overflow_safe = raw_value <= kMaxSafeSecondsToMicros &&
+                             raw_value >= kMinSafeSecondsToMicros)) {
+          value = raw_value * 1000000;
+        }
+        break;
+      case NANOARROW_TIME_UNIT_MILLI:
+        if ((overflow_safe = raw_value <= kMaxSafeMillisToMicros &&
+                             raw_value >= kMinSafeMillisToMicros)) {
+          value = raw_value * 1000;
+        }
+        break;
+      case NANOARROW_TIME_UNIT_MICRO:
+        value = raw_value;
+        break;
+      case NANOARROW_TIME_UNIT_NANO:
+        value = raw_value / 1000;
+        break;
+    }
+
+    if (!overflow_safe) {
+      ArrowErrorSet(
+          error, "Row %" PRId64 " duration value %" PRId64 " with unit %d would overflow",
+          index, raw_value, TU);
+      return ADBC_STATUS_INVALID_ARGUMENT;
+    }
+
+    // 2000-01-01 00:00:00.000000 in microseconds
+    constexpr uint32_t days = 0;
+    constexpr uint32_t months = 0;
+    NANOARROW_RETURN_NOT_OK(WriteChecked<int64_t>(buffer, value, error));
+    NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, days, error));
+    NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, months, error));
+
+    return ADBC_STATUS_OK;
+  }
+};
+
+class PostgresCopyBinaryFieldWriter : public PostgresCopyFieldWriter {
+ public:
+  ArrowErrorCode Write(ArrowBuffer* buffer, int64_t index, ArrowError* error) override {
+    struct ArrowBufferView buffer_view = ArrowArrayViewGetBytesUnsafe(array_view_, index);
+    NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, buffer_view.size_bytes, error));
+    NANOARROW_RETURN_NOT_OK(
+        ArrowBufferAppend(buffer, buffer_view.data.as_uint8, buffer_view.size_bytes));
+
+    return ADBC_STATUS_OK;
+  }
+};
+
+class PostgresCopyBinaryDictFieldWriter : public PostgresCopyFieldWriter {
+ public:
+  ArrowErrorCode Write(ArrowBuffer* buffer, int64_t index, ArrowError* error) override {
+    int64_t dict_index = ArrowArrayViewGetIntUnsafe(array_view_, index);
+    if (ArrowArrayViewIsNull(array_view_->dictionary, dict_index)) {
+      constexpr int32_t field_size_bytes = -1;
+      NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, field_size_bytes, error));
+    } else {
+      struct ArrowBufferView buffer_view =
+          ArrowArrayViewGetBytesUnsafe(array_view_->dictionary, dict_index);
+      NANOARROW_RETURN_NOT_OK(
+          WriteChecked<int32_t>(buffer, buffer_view.size_bytes, error));
+      NANOARROW_RETURN_NOT_OK(
+          ArrowBufferAppend(buffer, buffer_view.data.as_uint8, buffer_view.size_bytes));
+    }
+
+    return ADBC_STATUS_OK;
+  }
+};
+
+template <enum ArrowTimeUnit TU>
+class PostgresCopyTimestampFieldWriter : public PostgresCopyFieldWriter {
+ public:
+  ArrowErrorCode Write(ArrowBuffer* buffer, int64_t index, ArrowError* error) override {
+    constexpr int32_t field_size_bytes = sizeof(int64_t);
+    NANOARROW_RETURN_NOT_OK(WriteChecked<int32_t>(buffer, field_size_bytes, error));
+
+    int64_t raw_value = ArrowArrayViewGetIntUnsafe(array_view_, index);
+    int64_t value;
+
+    bool overflow_safe = true;
+    switch (TU) {
+      case NANOARROW_TIME_UNIT_SECOND:
+        if ((overflow_safe = raw_value <= kMaxSafeSecondsToMicros &&
+                             raw_value >= kMinSafeSecondsToMicros)) {
+          value = raw_value * 1000000;
+        }
+        break;
+      case NANOARROW_TIME_UNIT_MILLI:
+        if ((overflow_safe = raw_value <= kMaxSafeMillisToMicros &&
+                             raw_value >= kMinSafeMillisToMicros)) {
+          value = raw_value * 1000;
+        }
+        break;
+      case NANOARROW_TIME_UNIT_MICRO:
+        value = raw_value;
+        break;
+      case NANOARROW_TIME_UNIT_NANO:
+        value = raw_value / 1000;
+        break;
+    }
+
+    if (!overflow_safe) {
+      ArrowErrorSet(error,
+                    "[libpq] Row %" PRId64 " timestamp value %" PRId64
+                    " with unit %d would overflow",
+                    index, raw_value, TU);
+      return ADBC_STATUS_INVALID_ARGUMENT;
+    }
+
+    if (value < std::numeric_limits<int64_t>::min() + kPostgresTimestampEpoch) {
+      ArrowErrorSet(error,
+                    "[libpq] Row %" PRId64 " timestamp value %" PRId64
+                    " with unit %d would underflow",
+                    index, raw_value, TU);
+      return ADBC_STATUS_INVALID_ARGUMENT;
+    }
+
+    const int64_t scaled = value - kPostgresTimestampEpoch;
+    NANOARROW_RETURN_NOT_OK(WriteChecked<int64_t>(buffer, scaled, error));
+
+    return ADBC_STATUS_OK;
+  }
+};
+
+static inline ArrowErrorCode MakeCopyFieldWriter(struct ArrowSchema* schema,
+                                                 PostgresCopyFieldWriter** out,
+                                                 ArrowError* error) {
+  struct ArrowSchemaView schema_view;
+  NANOARROW_RETURN_NOT_OK(ArrowSchemaViewInit(&schema_view, schema, error));
+
+  switch (schema_view.type) {
+    case NANOARROW_TYPE_BOOL:
+      *out = new PostgresCopyBooleanFieldWriter();
+      return NANOARROW_OK;
+    case NANOARROW_TYPE_INT8:
+    case NANOARROW_TYPE_INT16:
+      *out = new PostgresCopyNetworkEndianFieldWriter<int16_t>();
+      return NANOARROW_OK;
+    case NANOARROW_TYPE_INT32:
+      *out = new PostgresCopyNetworkEndianFieldWriter<int32_t>();
+      return NANOARROW_OK;
+    case NANOARROW_TYPE_INT64:
+      *out = new PostgresCopyNetworkEndianFieldWriter<int64_t>();
+      return NANOARROW_OK;
+    case NANOARROW_TYPE_DATE32: {
+      constexpr int32_t kPostgresDateEpoch = 10957;
+      *out = new PostgresCopyNetworkEndianFieldWriter<int32_t, kPostgresDateEpoch>();
+      return NANOARROW_OK;
+    }
+    case NANOARROW_TYPE_FLOAT:
+      *out = new PostgresCopyFloatFieldWriter();
+      return NANOARROW_OK;
+    case NANOARROW_TYPE_DOUBLE:
+      *out = new PostgresCopyDoubleFieldWriter();
+      return NANOARROW_OK;
+    case NANOARROW_TYPE_BINARY:
+    case NANOARROW_TYPE_STRING:
+    case NANOARROW_TYPE_LARGE_STRING:
+      *out = new PostgresCopyBinaryFieldWriter();
+      return NANOARROW_OK;
+    case NANOARROW_TYPE_TIMESTAMP: {
+      switch (schema_view.time_unit) {
+        case NANOARROW_TIME_UNIT_NANO:
+          *out = new PostgresCopyTimestampFieldWriter<NANOARROW_TIME_UNIT_NANO>();
+          break;
+        case NANOARROW_TIME_UNIT_MILLI:
+          *out = new PostgresCopyTimestampFieldWriter<NANOARROW_TIME_UNIT_MILLI>();
+          break;
+        case NANOARROW_TIME_UNIT_MICRO:
+          *out = new PostgresCopyTimestampFieldWriter<NANOARROW_TIME_UNIT_MICRO>();
+          break;
+        case NANOARROW_TIME_UNIT_SECOND:
+          *out = new PostgresCopyTimestampFieldWriter<NANOARROW_TIME_UNIT_SECOND>();
+          break;
+      }
+      return NANOARROW_OK;
+    }
+    case NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO:
+      *out = new PostgresCopyIntervalFieldWriter();
+      return NANOARROW_OK;
+    case NANOARROW_TYPE_DURATION: {
+      switch (schema_view.time_unit) {
+        case NANOARROW_TIME_UNIT_SECOND:
+          *out = new PostgresCopyDurationFieldWriter<NANOARROW_TIME_UNIT_SECOND>();
+          break;
+        case NANOARROW_TIME_UNIT_MILLI:
+          *out = new PostgresCopyDurationFieldWriter<NANOARROW_TIME_UNIT_MILLI>();
+          break;
+        case NANOARROW_TIME_UNIT_MICRO:
+          *out = new PostgresCopyDurationFieldWriter<NANOARROW_TIME_UNIT_MICRO>();
+
+          break;
+        case NANOARROW_TIME_UNIT_NANO:
+          *out = new PostgresCopyDurationFieldWriter<NANOARROW_TIME_UNIT_NANO>();
+          break;
+      }
+      return NANOARROW_OK;
+    }
+    case NANOARROW_TYPE_DICTIONARY: {
+      struct ArrowSchemaView value_view;
+      NANOARROW_RETURN_NOT_OK(
+          ArrowSchemaViewInit(&value_view, schema->dictionary, error));
+      switch (value_view.type) {
+        case NANOARROW_TYPE_BINARY:
+        case NANOARROW_TYPE_STRING:
+        case NANOARROW_TYPE_LARGE_BINARY:
+        case NANOARROW_TYPE_LARGE_STRING:
+          *out = new PostgresCopyBinaryDictFieldWriter();
+          return NANOARROW_OK;
+        default:
+          break;
+      }
+    }
+    default:
+      break;
+  }
+
+  ArrowErrorSet(error, "COPY Writer not implemented for type %d", schema_view.type);
+  return EINVAL;
+}
+
+class PostgresCopyStreamWriter {
+ public:
+  ArrowErrorCode Init(struct ArrowSchema* schema) {
+    schema_ = schema;
+    NANOARROW_RETURN_NOT_OK(
+        ArrowArrayViewInitFromSchema(&array_view_.value, schema, nullptr));
+    root_writer_.Init(&array_view_.value);
+    ArrowBufferInit(&buffer_.value);
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode SetArray(struct ArrowArray* array) {
+    NANOARROW_RETURN_NOT_OK(ArrowArrayViewSetArray(&array_view_.value, array, nullptr));
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode WriteHeader(ArrowError* error) {
+    NANOARROW_RETURN_NOT_OK(ArrowBufferAppend(&buffer_.value, kPgCopyBinarySignature,
+                                              sizeof(kPgCopyBinarySignature)));
+
+    const uint32_t flag_fields = 0;
+    NANOARROW_RETURN_NOT_OK(
+        ArrowBufferAppend(&buffer_.value, &flag_fields, sizeof(flag_fields)));
+
+    const uint32_t extension_bytes = 0;
+    NANOARROW_RETURN_NOT_OK(
+        ArrowBufferAppend(&buffer_.value, &extension_bytes, sizeof(extension_bytes)));
+
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode WriteRecord(ArrowError* error) {
+    NANOARROW_RETURN_NOT_OK(root_writer_.Write(&buffer_.value, records_written_, error));
+    records_written_++;
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode InitFieldWriters(ArrowError* error) {
+    if (schema_->release == nullptr) {
+      return EINVAL;
+    }
+
+    for (int64_t i = 0; i < schema_->n_children; i++) {
+      PostgresCopyFieldWriter* child_writer = nullptr;
+      NANOARROW_RETURN_NOT_OK(
+          MakeCopyFieldWriter(schema_->children[i], &child_writer, error));
+      root_writer_.AppendChild(std::unique_ptr<PostgresCopyFieldWriter>(child_writer));
+    }
+
+    return NANOARROW_OK;
+  }
+
+  const struct ArrowBuffer& WriteBuffer() const { return buffer_.value; }
+
+  void Rewind() {
+    records_written_ = 0;
+    buffer_->size_bytes = 0;
+  }
+
+ private:
+  PostgresCopyFieldTupleWriter root_writer_;
+  struct ArrowSchema* schema_;
+  Handle<struct ArrowArrayView> array_view_;
+  Handle<struct ArrowBuffer> buffer_;
+  int64_t records_written_ = 0;
+};
+
+}  // namespace adbcpq

--- a/c/driver/netezza/postgres_copy_reader_test.cc
+++ b/c/driver/netezza/postgres_copy_reader_test.cc
@@ -1,0 +1,1313 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <optional>
+#include <tuple>
+
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
+#include <nanoarrow/nanoarrow.hpp>
+
+#include "postgres_copy_reader.h"
+#include "validation/adbc_validation_util.h"
+
+namespace adbcpq {
+
+class PostgresCopyStreamTester {
+ public:
+  ArrowErrorCode Init(const PostgresType& root_type, ArrowError* error = nullptr) {
+    NANOARROW_RETURN_NOT_OK(reader_.Init(root_type));
+    NANOARROW_RETURN_NOT_OK(reader_.InferOutputSchema(error));
+    NANOARROW_RETURN_NOT_OK(reader_.InitFieldReaders(error));
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode ReadAll(ArrowBufferView* data, ArrowError* error = nullptr) {
+    NANOARROW_RETURN_NOT_OK(reader_.ReadHeader(data, error));
+
+    int result;
+    do {
+      result = reader_.ReadRecord(data, error);
+    } while (result == NANOARROW_OK);
+
+    return result;
+  }
+
+  void GetSchema(ArrowSchema* out) { reader_.GetSchema(out); }
+
+  ArrowErrorCode GetArray(ArrowArray* out, ArrowError* error = nullptr) {
+    return reader_.GetArray(out, error);
+  }
+
+ private:
+  PostgresCopyStreamReader reader_;
+};
+
+class PostgresCopyStreamWriteTester {
+ public:
+  ArrowErrorCode Init(struct ArrowSchema* schema, struct ArrowArray* array,
+                      struct ArrowError* error = nullptr) {
+    NANOARROW_RETURN_NOT_OK(writer_.Init(schema));
+    NANOARROW_RETURN_NOT_OK(writer_.InitFieldWriters(error));
+    NANOARROW_RETURN_NOT_OK(writer_.SetArray(array));
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode WriteAll(struct ArrowError* error) {
+    NANOARROW_RETURN_NOT_OK(writer_.WriteHeader(error));
+
+    int result;
+    do {
+      result = writer_.WriteRecord(error);
+    } while (result == NANOARROW_OK);
+
+    return result;
+  }
+
+  ArrowErrorCode WriteArray(struct ArrowArray* array, struct ArrowError* error) {
+    writer_.SetArray(array);
+    int result;
+    do {
+      result = writer_.WriteRecord(error);
+    } while (result == NANOARROW_OK);
+
+    return result;
+  }
+
+  const struct ArrowBuffer& WriteBuffer() const { return writer_.WriteBuffer(); }
+
+  void Rewind() { writer_.Rewind(); }
+
+ private:
+  PostgresCopyStreamWriter writer_;
+};
+
+// COPY (SELECT CAST("col" AS BOOLEAN) AS "col" FROM (  VALUES (TRUE), (FALSE), (NULL)) AS
+// drvd("col")) TO STDOUT;
+static uint8_t kTestPgCopyBoolean[] = {
+    0x50, 0x47, 0x43, 0x4f, 0x50, 0x59, 0x0a, 0xff, 0x0d, 0x0a, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x01, 0x00, 0x01,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+TEST(PostgresCopyUtilsTest, PostgresCopyReadBoolean) {
+  ArrowBufferView data;
+  data.data.as_uint8 = kTestPgCopyBoolean;
+  data.size_bytes = sizeof(kTestPgCopyBoolean);
+
+  auto col_type = PostgresType(PostgresTypeId::kBool);
+  PostgresType input_type(PostgresTypeId::kRecord);
+  input_type.AppendChild("col", col_type);
+
+  PostgresCopyStreamTester tester;
+  ASSERT_EQ(tester.Init(input_type), NANOARROW_OK);
+  ASSERT_EQ(tester.ReadAll(&data), ENODATA);
+
+  ASSERT_EQ(data.data.as_uint8 - kTestPgCopyBoolean, sizeof(kTestPgCopyBoolean));
+  ASSERT_EQ(data.size_bytes, 0);
+
+  nanoarrow::UniqueArray array;
+  ASSERT_EQ(tester.GetArray(array.get()), NANOARROW_OK);
+  ASSERT_EQ(array->length, 3);
+  ASSERT_EQ(array->n_children, 1);
+
+  const uint8_t* validity =
+      reinterpret_cast<const uint8_t*>(array->children[0]->buffers[0]);
+  const uint8_t* data_buffer =
+      reinterpret_cast<const uint8_t*>(array->children[0]->buffers[1]);
+  ASSERT_NE(validity, nullptr);
+  ASSERT_NE(data_buffer, nullptr);
+
+  ASSERT_TRUE(ArrowBitGet(validity, 0));
+  ASSERT_TRUE(ArrowBitGet(validity, 1));
+  ASSERT_FALSE(ArrowBitGet(validity, 2));
+
+  ASSERT_TRUE(ArrowBitGet(data_buffer, 0));
+  ASSERT_FALSE(ArrowBitGet(data_buffer, 1));
+  ASSERT_FALSE(ArrowBitGet(data_buffer, 2));
+}
+
+TEST(PostgresCopyUtilsTest, PostgresCopyWriteBoolean) {
+  adbc_validation::Handle<struct ArrowSchema> schema;
+  adbc_validation::Handle<struct ArrowArray> array;
+  adbc_validation::Handle<struct ArrowBuffer> buffer;
+  struct ArrowError na_error;
+  ASSERT_EQ(adbc_validation::MakeSchema(&schema.value, {{"col", NANOARROW_TYPE_BOOL}}),
+            ADBC_STATUS_OK);
+  ASSERT_EQ(adbc_validation::MakeBatch<bool>(&schema.value, &array.value, &na_error,
+                                             {true, false, std::nullopt}),
+            ADBC_STATUS_OK);
+
+  PostgresCopyStreamWriteTester tester;
+  ASSERT_EQ(tester.Init(&schema.value, &array.value), NANOARROW_OK);
+  ASSERT_EQ(tester.WriteAll(nullptr), ENODATA);
+
+  const struct ArrowBuffer buf = tester.WriteBuffer();
+  // The last 2 bytes of a message can be transmitted via PQputCopyData
+  // so no need to test those bytes from the Writer
+  constexpr size_t buf_size = sizeof(kTestPgCopyBoolean) - 2;
+  ASSERT_EQ(buf.size_bytes, buf_size);
+  for (size_t i = 0; i < buf_size; i++) {
+    ASSERT_EQ(buf.data[i], kTestPgCopyBoolean[i]);
+  }
+}
+
+// COPY (SELECT CAST("col" AS SMALLINT) AS "col" FROM (  VALUES (-123), (-1), (1), (123),
+// (NULL)) AS drvd("col")) TO STDOUT WITH (FORMAT binary);
+static uint8_t kTestPgCopySmallInt[] = {
+    0x50, 0x47, 0x43, 0x4f, 0x50, 0x59, 0x0a, 0xff, 0x0d, 0x0a, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+    0x02, 0xff, 0x85, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0xff, 0xff, 0x00,
+    0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00,
+    0x02, 0x00, 0x7b, 0x00, 0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+TEST(PostgresCopyUtilsTest, PostgresCopyReadSmallInt) {
+  ArrowBufferView data;
+  data.data.as_uint8 = kTestPgCopySmallInt;
+  data.size_bytes = sizeof(kTestPgCopySmallInt);
+
+  auto col_type = PostgresType(PostgresTypeId::kInt2);
+  PostgresType input_type(PostgresTypeId::kRecord);
+  input_type.AppendChild("col", col_type);
+
+  PostgresCopyStreamTester tester;
+  ASSERT_EQ(tester.Init(input_type), NANOARROW_OK);
+  ASSERT_EQ(tester.ReadAll(&data), ENODATA);
+  ASSERT_EQ(data.data.as_uint8 - kTestPgCopySmallInt, sizeof(kTestPgCopySmallInt));
+  ASSERT_EQ(data.size_bytes, 0);
+
+  nanoarrow::UniqueArray array;
+  ASSERT_EQ(tester.GetArray(array.get()), NANOARROW_OK);
+  ASSERT_EQ(array->length, 5);
+  ASSERT_EQ(array->n_children, 1);
+
+  auto validity = reinterpret_cast<const uint8_t*>(array->children[0]->buffers[0]);
+  auto data_buffer = reinterpret_cast<const int16_t*>(array->children[0]->buffers[1]);
+  ASSERT_NE(validity, nullptr);
+  ASSERT_NE(data_buffer, nullptr);
+
+  ASSERT_TRUE(ArrowBitGet(validity, 0));
+  ASSERT_TRUE(ArrowBitGet(validity, 1));
+  ASSERT_TRUE(ArrowBitGet(validity, 2));
+  ASSERT_TRUE(ArrowBitGet(validity, 3));
+  ASSERT_FALSE(ArrowBitGet(validity, 4));
+
+  ASSERT_EQ(data_buffer[0], -123);
+  ASSERT_EQ(data_buffer[1], -1);
+  ASSERT_EQ(data_buffer[2], 1);
+  ASSERT_EQ(data_buffer[3], 123);
+  ASSERT_EQ(data_buffer[4], 0);
+}
+
+TEST(PostgresCopyUtilsTest, PostgresCopyWriteInt8) {
+  adbc_validation::Handle<struct ArrowSchema> schema;
+  adbc_validation::Handle<struct ArrowArray> array;
+  struct ArrowError na_error;
+  ASSERT_EQ(adbc_validation::MakeSchema(&schema.value, {{"col", NANOARROW_TYPE_INT8}}),
+            ADBC_STATUS_OK);
+  ASSERT_EQ(adbc_validation::MakeBatch<int8_t>(&schema.value, &array.value, &na_error,
+                                                {-123, -1, 1, 123, std::nullopt}),
+            ADBC_STATUS_OK);
+
+  PostgresCopyStreamWriteTester tester;
+  ASSERT_EQ(tester.Init(&schema.value, &array.value), NANOARROW_OK);
+  ASSERT_EQ(tester.WriteAll(nullptr), ENODATA);
+
+  const struct ArrowBuffer buf = tester.WriteBuffer();
+  // The last 2 bytes of a message can be transmitted via PQputCopyData
+  // so no need to test those bytes from the Writer
+  constexpr size_t buf_size = sizeof(kTestPgCopySmallInt) - 2;
+  ASSERT_EQ(buf.size_bytes, buf_size);
+  for (size_t i = 0; i < buf_size; i++) {
+    ASSERT_EQ(buf.data[i], kTestPgCopySmallInt[i]);
+  }
+}
+
+TEST(PostgresCopyUtilsTest, PostgresCopyWriteInt16) {
+  adbc_validation::Handle<struct ArrowSchema> schema;
+  adbc_validation::Handle<struct ArrowArray> array;
+  struct ArrowError na_error;
+  ASSERT_EQ(adbc_validation::MakeSchema(&schema.value, {{"col", NANOARROW_TYPE_INT16}}),
+            ADBC_STATUS_OK);
+  ASSERT_EQ(adbc_validation::MakeBatch<int16_t>(&schema.value, &array.value, &na_error,
+                                                {-123, -1, 1, 123, std::nullopt}),
+            ADBC_STATUS_OK);
+
+  PostgresCopyStreamWriteTester tester;
+  ASSERT_EQ(tester.Init(&schema.value, &array.value), NANOARROW_OK);
+  ASSERT_EQ(tester.WriteAll(nullptr), ENODATA);
+
+  const struct ArrowBuffer buf = tester.WriteBuffer();
+  // The last 2 bytes of a message can be transmitted via PQputCopyData
+  // so no need to test those bytes from the Writer
+  constexpr size_t buf_size = sizeof(kTestPgCopySmallInt) - 2;
+  ASSERT_EQ(buf.size_bytes, buf_size);
+  for (size_t i = 0; i < buf_size; i++) {
+    ASSERT_EQ(buf.data[i], kTestPgCopySmallInt[i]);
+  }
+}
+
+// COPY (SELECT CAST("col" AS INTEGER) AS "col" FROM (  VALUES (-123), (-1), (1), (123),
+// (NULL)) AS drvd("col")) TO STDOUT WITH (FORMAT binary);
+static uint8_t kTestPgCopyInteger[] = {
+    0x50, 0x47, 0x43, 0x4f, 0x50, 0x59, 0x0a, 0xff, 0x0d, 0x0a, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04, 0xff, 0xff, 0xff,
+    0x85, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04, 0xff, 0xff, 0xff, 0xff, 0x00, 0x01, 0x00,
+    0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04, 0x00,
+    0x00, 0x00, 0x7b, 0x00, 0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+TEST(PostgresCopyUtilsTest, PostgresCopyReadInteger) {
+  ArrowBufferView data;
+  data.data.as_uint8 = kTestPgCopyInteger;
+  data.size_bytes = sizeof(kTestPgCopyInteger);
+
+  auto col_type = PostgresType(PostgresTypeId::kInt4);
+  PostgresType input_type(PostgresTypeId::kRecord);
+  input_type.AppendChild("col", col_type);
+
+  PostgresCopyStreamTester tester;
+  ASSERT_EQ(tester.Init(input_type), NANOARROW_OK);
+  ASSERT_EQ(tester.ReadAll(&data), ENODATA);
+  ASSERT_EQ(data.data.as_uint8 - kTestPgCopyInteger, sizeof(kTestPgCopyInteger));
+  ASSERT_EQ(data.size_bytes, 0);
+
+  nanoarrow::UniqueArray array;
+  ASSERT_EQ(tester.GetArray(array.get()), NANOARROW_OK);
+  ASSERT_EQ(array->length, 5);
+  ASSERT_EQ(array->n_children, 1);
+
+  auto validity = reinterpret_cast<const uint8_t*>(array->children[0]->buffers[0]);
+  auto data_buffer = reinterpret_cast<const int32_t*>(array->children[0]->buffers[1]);
+  ASSERT_NE(validity, nullptr);
+  ASSERT_NE(data_buffer, nullptr);
+
+  ASSERT_TRUE(ArrowBitGet(validity, 0));
+  ASSERT_TRUE(ArrowBitGet(validity, 1));
+  ASSERT_TRUE(ArrowBitGet(validity, 2));
+  ASSERT_TRUE(ArrowBitGet(validity, 3));
+  ASSERT_FALSE(ArrowBitGet(validity, 4));
+
+  ASSERT_EQ(data_buffer[0], -123);
+  ASSERT_EQ(data_buffer[1], -1);
+  ASSERT_EQ(data_buffer[2], 1);
+  ASSERT_EQ(data_buffer[3], 123);
+  ASSERT_EQ(data_buffer[4], 0);
+}
+
+TEST(PostgresCopyUtilsTest, PostgresCopyWriteInt32) {
+  adbc_validation::Handle<struct ArrowSchema> schema;
+  adbc_validation::Handle<struct ArrowArray> array;
+  struct ArrowError na_error;
+  ASSERT_EQ(adbc_validation::MakeSchema(&schema.value, {{"col", NANOARROW_TYPE_INT32}}),
+            ADBC_STATUS_OK);
+  ASSERT_EQ(adbc_validation::MakeBatch<int32_t>(&schema.value, &array.value, &na_error,
+                                                {-123, -1, 1, 123, std::nullopt}),
+            ADBC_STATUS_OK);
+
+  PostgresCopyStreamWriteTester tester;
+  ASSERT_EQ(tester.Init(&schema.value, &array.value), NANOARROW_OK);
+  ASSERT_EQ(tester.WriteAll(nullptr), ENODATA);
+
+  const struct ArrowBuffer buf = tester.WriteBuffer();
+  // The last 2 bytes of a message can be transmitted via PQputCopyData
+  // so no need to test those bytes from the Writer
+  constexpr size_t buf_size = sizeof(kTestPgCopyInteger) - 2;
+  ASSERT_EQ(buf.size_bytes, buf_size);
+  for (size_t i = 0; i < buf_size; i++) {
+    ASSERT_EQ(buf.data[i], kTestPgCopyInteger[i]);
+  }
+}
+
+// COPY (SELECT CAST("col" AS BIGINT) AS "col" FROM (  VALUES (-123), (-1), (1), (123),
+// (NULL)) AS drvd("col")) TO STDOUT WITH (FORMAT binary);
+static uint8_t kTestPgCopyBigInt[] = {
+    0x50, 0x47, 0x43, 0x4f, 0x50, 0x59, 0x0a, 0xff, 0x0d, 0x0a, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x08, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0x85, 0x00, 0x01, 0x00, 0x00, 0x00, 0x08, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0x00, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x7b, 0x00, 0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+TEST(PostgresCopyUtilsTest, PostgresCopyReadBigInt) {
+  ArrowBufferView data;
+  data.data.as_uint8 = kTestPgCopyBigInt;
+  data.size_bytes = sizeof(kTestPgCopyBigInt);
+
+  auto col_type = PostgresType(PostgresTypeId::kInt8);
+  PostgresType input_type(PostgresTypeId::kRecord);
+  input_type.AppendChild("col", col_type);
+
+  PostgresCopyStreamTester tester;
+  ASSERT_EQ(tester.Init(input_type), NANOARROW_OK);
+  ASSERT_EQ(tester.ReadAll(&data), ENODATA);
+  ASSERT_EQ(data.data.as_uint8 - kTestPgCopyBigInt, sizeof(kTestPgCopyBigInt));
+  ASSERT_EQ(data.size_bytes, 0);
+
+  nanoarrow::UniqueArray array;
+  ASSERT_EQ(tester.GetArray(array.get()), NANOARROW_OK);
+  ASSERT_EQ(array->length, 5);
+  ASSERT_EQ(array->n_children, 1);
+
+  auto validity = reinterpret_cast<const uint8_t*>(array->children[0]->buffers[0]);
+  auto data_buffer = reinterpret_cast<const int64_t*>(array->children[0]->buffers[1]);
+  ASSERT_NE(validity, nullptr);
+  ASSERT_NE(data_buffer, nullptr);
+
+  ASSERT_TRUE(ArrowBitGet(validity, 0));
+  ASSERT_TRUE(ArrowBitGet(validity, 1));
+  ASSERT_TRUE(ArrowBitGet(validity, 2));
+  ASSERT_TRUE(ArrowBitGet(validity, 3));
+  ASSERT_FALSE(ArrowBitGet(validity, 4));
+
+  ASSERT_EQ(data_buffer[0], -123);
+  ASSERT_EQ(data_buffer[1], -1);
+  ASSERT_EQ(data_buffer[2], 1);
+  ASSERT_EQ(data_buffer[3], 123);
+  ASSERT_EQ(data_buffer[4], 0);
+}
+
+TEST(PostgresCopyUtilsTest, PostgresCopyWriteInt64) {
+  adbc_validation::Handle<struct ArrowSchema> schema;
+  adbc_validation::Handle<struct ArrowArray> array;
+  struct ArrowError na_error;
+  ASSERT_EQ(adbc_validation::MakeSchema(&schema.value, {{"col", NANOARROW_TYPE_INT64}}),
+            ADBC_STATUS_OK);
+  ASSERT_EQ(adbc_validation::MakeBatch<int64_t>(&schema.value, &array.value, &na_error,
+                                                {-123, -1, 1, 123, std::nullopt}),
+            ADBC_STATUS_OK);
+
+  PostgresCopyStreamWriteTester tester;
+  ASSERT_EQ(tester.Init(&schema.value, &array.value), NANOARROW_OK);
+  ASSERT_EQ(tester.WriteAll(nullptr), ENODATA);
+
+  const struct ArrowBuffer buf = tester.WriteBuffer();
+  // The last 2 bytes of a message can be transmitted via PQputCopyData
+  // so no need to test those bytes from the Writer
+  constexpr size_t buf_size = sizeof(kTestPgCopyBigInt) - 2;
+  ASSERT_EQ(buf.size_bytes, buf_size);
+  for (size_t i = 0; i < buf_size; i++) {
+    ASSERT_EQ(buf.data[i], kTestPgCopyBigInt[i]);
+  }
+}
+
+// COPY (SELECT CAST("col" AS REAL) AS "col" FROM (  VALUES (-123.456), (-1), (1),
+// (123.456), (NULL)) AS drvd("col")) TO STDOUT WITH (FORMAT binary);
+static uint8_t kTestPgCopyReal[] = {
+    0x50, 0x47, 0x43, 0x4f, 0x50, 0x59, 0x0a, 0xff, 0x0d, 0x0a, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04, 0xc2, 0xf6, 0xe9,
+    0x79, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04, 0xbf, 0x80, 0x00, 0x00, 0x00, 0x01, 0x00,
+    0x00, 0x00, 0x04, 0x3f, 0x80, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04, 0x42,
+    0xf6, 0xe9, 0x79, 0x00, 0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+TEST(PostgresCopyUtilsTest, PostgresCopyReadReal) {
+  ArrowBufferView data;
+  data.data.as_uint8 = kTestPgCopyReal;
+  data.size_bytes = sizeof(kTestPgCopyReal);
+
+  auto col_type = PostgresType(PostgresTypeId::kFloat4);
+  PostgresType input_type(PostgresTypeId::kRecord);
+  input_type.AppendChild("col", col_type);
+
+  PostgresCopyStreamTester tester;
+  ASSERT_EQ(tester.Init(input_type), NANOARROW_OK);
+  ASSERT_EQ(tester.ReadAll(&data), ENODATA);
+  ASSERT_EQ(data.data.as_uint8 - kTestPgCopyReal, sizeof(kTestPgCopyReal));
+  ASSERT_EQ(data.size_bytes, 0);
+
+  nanoarrow::UniqueArray array;
+  ASSERT_EQ(tester.GetArray(array.get()), NANOARROW_OK);
+  ASSERT_EQ(array->length, 5);
+  ASSERT_EQ(array->n_children, 1);
+
+  auto validity = reinterpret_cast<const uint8_t*>(array->children[0]->buffers[0]);
+  auto data_buffer = reinterpret_cast<const float*>(array->children[0]->buffers[1]);
+  ASSERT_NE(validity, nullptr);
+  ASSERT_NE(data_buffer, nullptr);
+
+  ASSERT_TRUE(ArrowBitGet(validity, 0));
+  ASSERT_TRUE(ArrowBitGet(validity, 1));
+  ASSERT_TRUE(ArrowBitGet(validity, 2));
+  ASSERT_TRUE(ArrowBitGet(validity, 3));
+  ASSERT_FALSE(ArrowBitGet(validity, 4));
+
+  ASSERT_FLOAT_EQ(data_buffer[0], -123.456);
+  ASSERT_EQ(data_buffer[1], -1);
+  ASSERT_EQ(data_buffer[2], 1);
+  ASSERT_FLOAT_EQ(data_buffer[3], 123.456);
+  ASSERT_EQ(data_buffer[4], 0);
+}
+
+TEST(PostgresCopyUtilsTest, PostgresCopyWriteReal) {
+  adbc_validation::Handle<struct ArrowSchema> schema;
+  adbc_validation::Handle<struct ArrowArray> array;
+  struct ArrowError na_error;
+  ASSERT_EQ(adbc_validation::MakeSchema(&schema.value, {{"col", NANOARROW_TYPE_FLOAT}}),
+            ADBC_STATUS_OK);
+  ASSERT_EQ(adbc_validation::MakeBatch<float>(&schema.value, &array.value, &na_error,
+                                              {-123.456, -1, 1, 123.456, std::nullopt}),
+            ADBC_STATUS_OK);
+
+  PostgresCopyStreamWriteTester tester;
+  ASSERT_EQ(tester.Init(&schema.value, &array.value), NANOARROW_OK);
+  ASSERT_EQ(tester.WriteAll(nullptr), ENODATA);
+
+  const struct ArrowBuffer buf = tester.WriteBuffer();
+  // The last 2 bytes of a message can be transmitted via PQputCopyData
+  // so no need to test those bytes from the Writer
+  constexpr size_t buf_size = sizeof(kTestPgCopyReal) - 2;
+  ASSERT_EQ(buf.size_bytes, buf_size);
+  for (size_t i = 0; i < buf_size; i++) {
+    ASSERT_EQ(buf.data[i], kTestPgCopyReal[i]) << " mismatch at index: " << i;
+  }
+}
+
+// COPY (SELECT CAST("col" AS DOUBLE PRECISION) AS "col" FROM (  VALUES (-123.456), (-1),
+// (1), (123.456), (NULL)) AS drvd("col")) TO STDOUT WITH (FORMAT binary);
+static uint8_t kTestPgCopyDoublePrecision[] = {
+    0x50, 0x47, 0x43, 0x4f, 0x50, 0x59, 0x0a, 0xff, 0x0d, 0x0a, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x08, 0xc0, 0x5e, 0xdd,
+    0x2f, 0x1a, 0x9f, 0xbe, 0x77, 0x00, 0x01, 0x00, 0x00, 0x00, 0x08, 0xbf, 0xf0, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x08, 0x3f, 0xf0, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x08, 0x40, 0x5e, 0xdd,
+    0x2f, 0x1a, 0x9f, 0xbe, 0x77, 0x00, 0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+TEST(PostgresCopyUtilsTest, PostgresCopyReadDoublePrecision) {
+  ArrowBufferView data;
+  data.data.as_uint8 = kTestPgCopyDoublePrecision;
+  data.size_bytes = sizeof(kTestPgCopyDoublePrecision);
+
+  auto col_type = PostgresType(PostgresTypeId::kFloat8);
+  PostgresType input_type(PostgresTypeId::kRecord);
+  input_type.AppendChild("col", col_type);
+
+  PostgresCopyStreamTester tester;
+  ASSERT_EQ(tester.Init(input_type), NANOARROW_OK);
+  ASSERT_EQ(tester.ReadAll(&data), ENODATA);
+  ASSERT_EQ(data.data.as_uint8 - kTestPgCopyDoublePrecision,
+            sizeof(kTestPgCopyDoublePrecision));
+  ASSERT_EQ(data.size_bytes, 0);
+
+  nanoarrow::UniqueArray array;
+  ASSERT_EQ(tester.GetArray(array.get()), NANOARROW_OK);
+  ASSERT_EQ(array->length, 5);
+  ASSERT_EQ(array->n_children, 1);
+
+  auto validity = reinterpret_cast<const uint8_t*>(array->children[0]->buffers[0]);
+  auto data_buffer = reinterpret_cast<const double*>(array->children[0]->buffers[1]);
+  ASSERT_NE(validity, nullptr);
+  ASSERT_NE(data_buffer, nullptr);
+
+  ASSERT_TRUE(ArrowBitGet(validity, 0));
+  ASSERT_TRUE(ArrowBitGet(validity, 1));
+  ASSERT_TRUE(ArrowBitGet(validity, 2));
+  ASSERT_TRUE(ArrowBitGet(validity, 3));
+  ASSERT_FALSE(ArrowBitGet(validity, 4));
+
+  ASSERT_DOUBLE_EQ(data_buffer[0], -123.456);
+  ASSERT_EQ(data_buffer[1], -1);
+  ASSERT_EQ(data_buffer[2], 1);
+  ASSERT_DOUBLE_EQ(data_buffer[3], 123.456);
+  ASSERT_EQ(data_buffer[4], 0);
+}
+
+TEST(PostgresCopyUtilsTest, PostgresCopyWriteDoublePrecision) {
+  adbc_validation::Handle<struct ArrowSchema> schema;
+  adbc_validation::Handle<struct ArrowArray> array;
+  struct ArrowError na_error;
+  ASSERT_EQ(adbc_validation::MakeSchema(&schema.value, {{"col", NANOARROW_TYPE_DOUBLE}}),
+            ADBC_STATUS_OK);
+  ASSERT_EQ(adbc_validation::MakeBatch<double>(&schema.value, &array.value, &na_error,
+                                               {-123.456, -1, 1, 123.456, std::nullopt}),
+            ADBC_STATUS_OK);
+
+  PostgresCopyStreamWriteTester tester;
+  ASSERT_EQ(tester.Init(&schema.value, &array.value), NANOARROW_OK);
+  ASSERT_EQ(tester.WriteAll(nullptr), ENODATA);
+
+  const struct ArrowBuffer buf = tester.WriteBuffer();
+  // The last 2 bytes of a message can be transmitted via PQputCopyData
+  // so no need to test those bytes from the Writer
+  constexpr size_t buf_size = sizeof(kTestPgCopyDoublePrecision) - 2;
+  ASSERT_EQ(buf.size_bytes, buf_size);
+  for (size_t i = 0; i < buf_size; i++) {
+    ASSERT_EQ(buf.data[i], kTestPgCopyDoublePrecision[i]);
+  }
+}
+
+static uint8_t kTestPgCopyDate[] = {
+    0x50, 0x47, 0x43, 0x4f, 0x50, 0x59, 0x0a, 0xff, 0x0d, 0x0a, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04, 0xff, 0xff,
+    0x71, 0x54, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x8e, 0xad, 0x00, 0x01,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+TEST(PostgresCopyUtilsTest, PostgresCopyReadDate) {
+  ArrowBufferView data;
+  data.data.as_uint8 = kTestPgCopyDate;
+  data.size_bytes = sizeof(kTestPgCopyDate);
+
+  auto col_type = PostgresType(PostgresTypeId::kDate);
+  PostgresType input_type(PostgresTypeId::kRecord);
+  input_type.AppendChild("col", col_type);
+
+  PostgresCopyStreamTester tester;
+  ASSERT_EQ(tester.Init(input_type), NANOARROW_OK);
+  ASSERT_EQ(tester.ReadAll(&data), ENODATA);
+  ASSERT_EQ(data.data.as_uint8 - kTestPgCopyDate, sizeof(kTestPgCopyDate));
+  ASSERT_EQ(data.size_bytes, 0);
+
+  nanoarrow::UniqueArray array;
+  ASSERT_EQ(tester.GetArray(array.get()), NANOARROW_OK);
+  ASSERT_EQ(array->length, 3);
+  ASSERT_EQ(array->n_children, 1);
+
+  auto validity = reinterpret_cast<const uint8_t*>(array->children[0]->buffers[0]);
+  auto data_buffer = reinterpret_cast<const int32_t*>(array->children[0]->buffers[1]);
+  ASSERT_NE(validity, nullptr);
+  ASSERT_NE(data_buffer, nullptr);
+
+  ASSERT_TRUE(ArrowBitGet(validity, 0));
+  ASSERT_TRUE(ArrowBitGet(validity, 1));
+  ASSERT_FALSE(ArrowBitGet(validity, 2));
+
+  ASSERT_EQ(data_buffer[0], -25567);
+  ASSERT_EQ(data_buffer[1], 47482);
+}
+
+TEST(PostgresCopyUtilsTest, PostgresCopyWriteDate) {
+  adbc_validation::Handle<struct ArrowSchema> schema;
+  adbc_validation::Handle<struct ArrowArray> array;
+  struct ArrowError na_error;
+  ASSERT_EQ(adbc_validation::MakeSchema(&schema.value, {{"col", NANOARROW_TYPE_DATE32}}),
+            ADBC_STATUS_OK);
+  ASSERT_EQ(adbc_validation::MakeBatch<int32_t>(&schema.value, &array.value, &na_error,
+                                                {-25567, 47482, std::nullopt}),
+            ADBC_STATUS_OK);
+
+  PostgresCopyStreamWriteTester tester;
+  ASSERT_EQ(tester.Init(&schema.value, &array.value), NANOARROW_OK);
+  ASSERT_EQ(tester.WriteAll(nullptr), ENODATA);
+
+  const struct ArrowBuffer buf = tester.WriteBuffer();
+  // The last 2 bytes of a message can be transmitted via PQputCopyData
+  // so no need to test those bytes from the Writer
+  constexpr size_t buf_size = sizeof(kTestPgCopyDate) - 2;
+  ASSERT_EQ(buf.size_bytes, buf_size);
+  for (size_t i = 0; i < buf_size; i++) {
+    ASSERT_EQ(buf.data[i], kTestPgCopyDate[i]);
+  }
+}
+
+
+// For full coverage, ensure that this contains NUMERIC examples that:
+// - Have >= four zeroes to the left of the decimal point
+// - Have >= four zeroes to the right of the decimal point
+// - Include special values (nan, -inf, inf, NULL)
+// - Have >= four trailing zeroes to the right of the decimal point
+// - Have >= four leading zeroes before the first digit to the right of the decimal point
+// - Is < 0 (negative)
+// COPY (SELECT CAST(col AS NUMERIC) AS col FROM (  VALUES (1000000), ('0.00001234'),
+// ('1.0000'), (-123.456), (123.456), ('nan'), ('-inf'), ('inf'), (NULL)) AS drvd(col)) TO
+// STDOUT WITH (FORMAT binary);
+static uint8_t kTestPgCopyNumeric[] = {
+    0x50, 0x47, 0x43, 0x4f, 0x50, 0x59, 0x0a, 0xff, 0x0d, 0x0a, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x01, 0x00,
+    0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x64, 0x00, 0x01, 0x00, 0x00, 0x00, 0x0a, 0x00,
+    0x01, 0xff, 0xfe, 0x00, 0x00, 0x00, 0x08, 0x04, 0xd2, 0x00, 0x01, 0x00, 0x00, 0x00,
+    0x0a, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x01, 0x00, 0x01, 0x00,
+    0x00, 0x00, 0x0c, 0x00, 0x02, 0x00, 0x00, 0x40, 0x00, 0x00, 0x03, 0x00, 0x7b, 0x11,
+    0xd0, 0x00, 0x01, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x03, 0x00, 0x7b, 0x11, 0xd0, 0x00, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00,
+    0x00, 0xc0, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00,
+    0x00, 0xf0, 0x00, 0x00, 0x20, 0x00, 0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00,
+    0x00, 0xd0, 0x00, 0x00, 0x20, 0x00, 0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+TEST(PostgresCopyUtilsTest, PostgresCopyReadNumeric) {
+  ArrowBufferView data;
+  data.data.as_uint8 = kTestPgCopyNumeric;
+  data.size_bytes = sizeof(kTestPgCopyNumeric);
+
+  auto col_type = PostgresType(PostgresTypeId::kNumeric);
+  PostgresType input_type(PostgresTypeId::kRecord);
+  input_type.AppendChild("col", col_type);
+
+  PostgresCopyStreamTester tester;
+  ASSERT_EQ(tester.Init(input_type), NANOARROW_OK);
+  ASSERT_EQ(tester.ReadAll(&data), ENODATA);
+  ASSERT_EQ(data.data.as_uint8 - kTestPgCopyNumeric, sizeof(kTestPgCopyNumeric));
+  ASSERT_EQ(data.size_bytes, 0);
+
+  nanoarrow::UniqueArray array;
+  ASSERT_EQ(tester.GetArray(array.get()), NANOARROW_OK);
+  ASSERT_EQ(array->length, 9);
+  ASSERT_EQ(array->n_children, 1);
+
+  nanoarrow::UniqueSchema schema;
+  tester.GetSchema(schema.get());
+
+  nanoarrow::UniqueArrayView array_view;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(array_view.get(), schema.get(), nullptr),
+            NANOARROW_OK);
+  ASSERT_EQ(array_view->children[0]->storage_type, NANOARROW_TYPE_STRING);
+  ASSERT_EQ(ArrowArrayViewSetArray(array_view.get(), array.get(), nullptr), NANOARROW_OK);
+
+  auto validity = array_view->children[0]->buffer_views[0].data.as_uint8;
+  ASSERT_TRUE(ArrowBitGet(validity, 0));
+  ASSERT_TRUE(ArrowBitGet(validity, 1));
+  ASSERT_TRUE(ArrowBitGet(validity, 2));
+  ASSERT_TRUE(ArrowBitGet(validity, 3));
+  ASSERT_TRUE(ArrowBitGet(validity, 4));
+  ASSERT_TRUE(ArrowBitGet(validity, 5));
+  ASSERT_TRUE(ArrowBitGet(validity, 6));
+  ASSERT_TRUE(ArrowBitGet(validity, 7));
+  ASSERT_FALSE(ArrowBitGet(validity, 8));
+
+  struct ArrowStringView item;
+  item = ArrowArrayViewGetStringUnsafe(array_view->children[0], 0);
+  EXPECT_EQ(std::string(item.data, item.size_bytes), "1000000");
+  item = ArrowArrayViewGetStringUnsafe(array_view->children[0], 1);
+  EXPECT_EQ(std::string(item.data, item.size_bytes), "0.00001234");
+  item = ArrowArrayViewGetStringUnsafe(array_view->children[0], 2);
+  EXPECT_EQ(std::string(item.data, item.size_bytes), "1.0000");
+  item = ArrowArrayViewGetStringUnsafe(array_view->children[0], 3);
+  EXPECT_EQ(std::string(item.data, item.size_bytes), "-123.456");
+  item = ArrowArrayViewGetStringUnsafe(array_view->children[0], 4);
+  EXPECT_EQ(std::string(item.data, item.size_bytes), "123.456");
+  item = ArrowArrayViewGetStringUnsafe(array_view->children[0], 5);
+  EXPECT_EQ(std::string(item.data, item.size_bytes), "nan");
+  item = ArrowArrayViewGetStringUnsafe(array_view->children[0], 6);
+  EXPECT_EQ(std::string(item.data, item.size_bytes), "-inf");
+  item = ArrowArrayViewGetStringUnsafe(array_view->children[0], 7);
+  EXPECT_EQ(std::string(item.data, item.size_bytes), "inf");
+}
+
+// COPY (SELECT CAST(col AS TIMESTAMP) FROM (  VALUES ('1900-01-01 12:34:56'),
+// ('2100-01-01 12:34:56'), (NULL)) AS drvd("col")) TO STDOUT WITH (FORMAT BINARY);
+static uint8_t kTestPgCopyTimestamp[] = {
+    0x50, 0x47, 0x43, 0x4f, 0x50, 0x59, 0x0a, 0xff, 0x0d, 0x0a, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+    0x00, 0x08, 0xff, 0xf4, 0xc9, 0xf9, 0x07, 0xe5, 0x9c, 0x00, 0x00,
+    0x01, 0x00, 0x00, 0x00, 0x08, 0x00, 0x0b, 0x36, 0x30, 0x2d, 0xa5,
+    0xfc, 0x00, 0x00, 0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+TEST(PostgresCopyUtilsTest, PostgresCopyReadTimestamp) {
+  ArrowBufferView data;
+  data.data.as_uint8 = kTestPgCopyTimestamp;
+  data.size_bytes = sizeof(kTestPgCopyTimestamp);
+
+  auto col_type = PostgresType(PostgresTypeId::kTimestamp);
+  PostgresType input_type(PostgresTypeId::kRecord);
+  input_type.AppendChild("col", col_type);
+
+  PostgresCopyStreamTester tester;
+  ASSERT_EQ(tester.Init(input_type), NANOARROW_OK);
+  ASSERT_EQ(tester.ReadAll(&data), ENODATA);
+  ASSERT_EQ(data.data.as_uint8 - kTestPgCopyTimestamp, sizeof(kTestPgCopyTimestamp));
+  ASSERT_EQ(data.size_bytes, 0);
+
+  nanoarrow::UniqueArray array;
+  ASSERT_EQ(tester.GetArray(array.get()), NANOARROW_OK);
+  ASSERT_EQ(array->length, 3);
+  ASSERT_EQ(array->n_children, 1);
+
+  auto validity = reinterpret_cast<const uint8_t*>(array->children[0]->buffers[0]);
+  auto data_buffer = reinterpret_cast<const int64_t*>(array->children[0]->buffers[1]);
+  ASSERT_NE(validity, nullptr);
+  ASSERT_NE(data_buffer, nullptr);
+
+  ASSERT_TRUE(ArrowBitGet(validity, 0));
+  ASSERT_TRUE(ArrowBitGet(validity, 1));
+  ASSERT_FALSE(ArrowBitGet(validity, 3));
+
+  ASSERT_EQ(data_buffer[0], -2208943504000000);
+  ASSERT_EQ(data_buffer[1], 4102490096000000);
+}
+
+using TimestampTestParamType = std::tuple<enum ArrowTimeUnit,
+                                          const char *,
+                                          std::vector<std::optional<int64_t>>>;
+
+class PostgresCopyWriteTimestampTest : public testing::TestWithParam<
+  TimestampTestParamType> {
+};
+
+TEST_P(PostgresCopyWriteTimestampTest, WritesProperBufferValues) {
+  adbc_validation::Handle<struct ArrowSchema> schema;
+  adbc_validation::Handle<struct ArrowArray> array;
+  struct ArrowError na_error;
+
+  TimestampTestParamType parameters = GetParam();
+  enum ArrowTimeUnit unit = std::get<0>(parameters);
+  const char* timezone = std::get<1>(parameters);
+
+  const std::vector<std::optional<int64_t>> values = std::get<2>(parameters);
+
+  ArrowSchemaInit(&schema.value);
+  ArrowSchemaSetTypeStruct(&schema.value, 1);
+  ArrowSchemaSetTypeDateTime(schema->children[0],
+                             NANOARROW_TYPE_TIMESTAMP,
+                             unit,
+                             timezone);
+  ArrowSchemaSetName(schema->children[0], "col");
+  ASSERT_EQ(adbc_validation::MakeBatch<int64_t>(&schema.value,
+                                                &array.value,
+                                                &na_error,
+                                                values),
+              ADBC_STATUS_OK);
+
+  PostgresCopyStreamWriteTester tester;
+  ASSERT_EQ(tester.Init(&schema.value, &array.value), NANOARROW_OK);
+  ASSERT_EQ(tester.WriteAll(nullptr), ENODATA);
+
+  const struct ArrowBuffer buf = tester.WriteBuffer();
+  // The last 2 bytes of a message can be transmitted via PQputCopyData
+  // so no need to test those bytes from the Writer
+  constexpr size_t buf_size = sizeof(kTestPgCopyTimestamp) - 2;
+  ASSERT_EQ(buf.size_bytes, buf_size);
+  for (size_t i = 0; i < buf_size; i++) {
+    ASSERT_EQ(buf.data[i], kTestPgCopyTimestamp[i]);
+  }
+}
+
+static const std::vector<TimestampTestParamType> ts_values {
+  {NANOARROW_TIME_UNIT_SECOND, nullptr,
+   {-2208943504, 4102490096, std::nullopt}},
+  {NANOARROW_TIME_UNIT_MILLI, nullptr,
+   {-2208943504000, 4102490096000, std::nullopt}},
+  {NANOARROW_TIME_UNIT_MICRO, nullptr,
+   {-2208943504000000, 4102490096000000, std::nullopt}},
+  {NANOARROW_TIME_UNIT_NANO, nullptr,
+   {-2208943504000000000, 4102490096000000000, std::nullopt}},
+  {NANOARROW_TIME_UNIT_SECOND, "UTC",
+   {-2208943504, 4102490096, std::nullopt}},
+  {NANOARROW_TIME_UNIT_MILLI, "UTC",
+   {-2208943504000, 4102490096000, std::nullopt}},
+  {NANOARROW_TIME_UNIT_MICRO, "UTC",
+   {-2208943504000000, 4102490096000000, std::nullopt}},
+  {NANOARROW_TIME_UNIT_NANO, "UTC",
+   {-2208943504000000000, 4102490096000000000, std::nullopt}},
+  {NANOARROW_TIME_UNIT_SECOND, "America/New_York",
+   {-2208943504, 4102490096, std::nullopt}},
+  {NANOARROW_TIME_UNIT_MILLI, "America/New_York",
+   {-2208943504000, 4102490096000, std::nullopt}},
+  {NANOARROW_TIME_UNIT_MICRO, "America/New_York",
+   {-2208943504000000, 4102490096000000, std::nullopt}},
+  {NANOARROW_TIME_UNIT_NANO, "America/New_York",
+   {-2208943504000000000, 4102490096000000000, std::nullopt}},
+};
+
+INSTANTIATE_TEST_SUITE_P(PostgresCopyWriteTimestamp,
+                         PostgresCopyWriteTimestampTest,
+                         testing::ValuesIn(ts_values));
+
+// COPY (SELECT CAST(col AS INTERVAL) FROM (  VALUES ('-1 months -2 days -4 seconds'),
+// ('1 months 2 days 4 seconds'), (NULL)) AS drvd("col")) TO STDOUT WITH (FORMAT BINARY);
+static uint8_t kTestPgCopyInterval[] = {
+    0x50, 0x47, 0x43, 0x4f, 0x50, 0x59, 0x0a, 0xff, 0x0d, 0x0a, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x10, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xc2, 0xf7, 0x00, 0xff, 0xff, 0xff, 0xfe, 0xff, 0xff, 0xff,
+    0xff, 0x00, 0x01, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x3d, 0x09,
+    0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff};
+
+TEST(PostgresCopyUtilsTest, PostgresCopyReadInterval) {
+  ArrowBufferView data;
+  data.data.as_uint8 = kTestPgCopyInterval;
+  data.size_bytes = sizeof(kTestPgCopyInterval);
+
+  auto col_type = PostgresType(PostgresTypeId::kInterval);
+  PostgresType input_type(PostgresTypeId::kRecord);
+  input_type.AppendChild("col", col_type);
+
+  PostgresCopyStreamTester tester;
+  ASSERT_EQ(tester.Init(input_type), NANOARROW_OK);
+  ASSERT_EQ(tester.ReadAll(&data), ENODATA);
+  ASSERT_EQ(data.data.as_uint8 - kTestPgCopyInterval, sizeof(kTestPgCopyInterval));
+  ASSERT_EQ(data.size_bytes, 0);
+
+  nanoarrow::UniqueArray array;
+  ASSERT_EQ(tester.GetArray(array.get()), NANOARROW_OK);
+  ASSERT_EQ(array->length, 3);
+  ASSERT_EQ(array->n_children, 1);
+
+  nanoarrow::UniqueSchema schema;
+  tester.GetSchema(schema.get());
+
+  nanoarrow::UniqueArrayView array_view;
+  ASSERT_EQ(ArrowArrayViewInitFromSchema(array_view.get(), schema.get(), nullptr),
+            NANOARROW_OK);
+  ASSERT_EQ(array_view->children[0]->storage_type,
+            NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO);
+  ASSERT_EQ(ArrowArrayViewSetArray(array_view.get(), array.get(), nullptr), NANOARROW_OK);
+
+  auto validity = array_view->children[0]->buffer_views[0].data.as_uint8;
+  ASSERT_TRUE(ArrowBitGet(validity, 0));
+  ASSERT_TRUE(ArrowBitGet(validity, 1));
+  ASSERT_FALSE(ArrowBitGet(validity, 2));
+
+  struct ArrowInterval interval;
+  ArrowIntervalInit(&interval, NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO);
+  ArrowArrayViewGetIntervalUnsafe(array_view->children[0], 0, &interval);
+  ASSERT_EQ(interval.months, -1);
+  ASSERT_EQ(interval.days, -2);
+  ASSERT_EQ(interval.ns, -4000000000);
+  ArrowArrayViewGetIntervalUnsafe(array_view->children[0], 1, &interval);
+  ASSERT_EQ(interval.months, 1);
+  ASSERT_EQ(interval.days, 2);
+  ASSERT_EQ(interval.ns, 4000000000);
+}
+
+TEST(PostgresCopyUtilsTest, PostgresCopyWriteInterval) {
+  adbc_validation::Handle<struct ArrowSchema> schema;
+  adbc_validation::Handle<struct ArrowArray> array;
+  struct ArrowError na_error;
+  const enum ArrowType type = NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO;
+  // values are days, months, ns
+  struct ArrowInterval neg_interval;
+  struct ArrowInterval pos_interval;
+
+  ArrowIntervalInit(&neg_interval, type);
+  ArrowIntervalInit(&pos_interval, type);
+
+  neg_interval.months = -1;
+  neg_interval.days = -2;
+  neg_interval.ns = -4000000000;
+
+  pos_interval.months = 1;
+  pos_interval.days = 2;
+  pos_interval.ns = 4000000000;
+
+  const std::vector<std::optional<ArrowInterval*>> values = {
+    &neg_interval, &pos_interval, std::nullopt};
+
+  ASSERT_EQ(adbc_validation::MakeSchema(&schema.value, {{"col", type}}), ADBC_STATUS_OK);
+
+  ASSERT_EQ(adbc_validation::MakeBatch<ArrowInterval*>(
+              &schema.value, &array.value, &na_error, values), ADBC_STATUS_OK);
+
+  PostgresCopyStreamWriteTester tester;
+  ASSERT_EQ(tester.Init(&schema.value, &array.value), NANOARROW_OK);
+  ASSERT_EQ(tester.WriteAll(nullptr), ENODATA);
+
+  const struct ArrowBuffer buf = tester.WriteBuffer();
+  // The last 2 bytes of a message can be transmitted via PQputCopyData
+  // so no need to test those bytes from the Writer
+  constexpr size_t buf_size = sizeof(kTestPgCopyInterval) - 2;
+  ASSERT_EQ(buf.size_bytes, buf_size);
+  for (size_t i = 0; i < buf_size; i++) {
+    ASSERT_EQ(buf.data[i], kTestPgCopyInterval[i]);
+  }
+}
+
+// Writing a DURATION from NANOARROW produces INTERVAL in postgres without day/month
+// COPY (SELECT CAST(col AS INTERVAL) FROM (  VALUES ('-4 seconds'),
+// ('4 seconds'), (NULL)) AS drvd("col")) TO STDOUT WITH (FORMAT BINARY);
+static uint8_t kTestPgCopyDuration[] = {
+    0x50, 0x47, 0x43, 0x4f, 0x50, 0x59, 0x0a, 0xff, 0x0d, 0x0a, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x10, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xc2, 0xf7, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x3d, 0x09,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff};
+using DurationTestParamType = std::tuple<enum ArrowTimeUnit,
+  std::vector<std::optional<int64_t>>>;
+
+class PostgresCopyWriteDurationTest : public testing::TestWithParam<
+  DurationTestParamType> {};
+
+TEST_P(PostgresCopyWriteDurationTest, WritesProperBufferValues) {
+  adbc_validation::Handle<struct ArrowSchema> schema;
+  adbc_validation::Handle<struct ArrowArray> array;
+  struct ArrowError na_error;
+  const enum ArrowType type = NANOARROW_TYPE_DURATION;
+
+  DurationTestParamType parameters = GetParam();
+  enum ArrowTimeUnit unit = std::get<0>(parameters);
+  const std::vector<std::optional<int64_t>> values = std::get<1>(parameters);
+
+  ArrowSchemaInit(&schema.value);
+  ArrowSchemaSetTypeStruct(&schema.value, 1);
+  ArrowSchemaSetTypeDateTime(schema->children[0], type, unit, nullptr);
+  ArrowSchemaSetName(schema->children[0], "col");
+  ASSERT_EQ(adbc_validation::MakeBatch<int64_t>(
+              &schema.value, &array.value, &na_error, values), ADBC_STATUS_OK);
+
+  PostgresCopyStreamWriteTester tester;
+  ASSERT_EQ(tester.Init(&schema.value, &array.value), NANOARROW_OK);
+  ASSERT_EQ(tester.WriteAll(nullptr), ENODATA);
+
+  const struct ArrowBuffer buf = tester.WriteBuffer();
+  // The last 2 bytes of a message can be transmitted via PQputCopyData
+  // so no need to test those bytes from the Writer
+  constexpr size_t buf_size = sizeof(kTestPgCopyDuration) - 2;
+  ASSERT_EQ(buf.size_bytes, buf_size);
+  for (size_t i = 0; i < buf_size; i++) {
+    ASSERT_EQ(buf.data[i], kTestPgCopyDuration[i]);
+  }
+}
+
+static const std::vector<DurationTestParamType> duration_params {
+  {NANOARROW_TIME_UNIT_SECOND, {-4, 4, std::nullopt}},
+  {NANOARROW_TIME_UNIT_MILLI, {-4000, 4000, std::nullopt}},
+  {NANOARROW_TIME_UNIT_MICRO, {-4000000, 4000000, std::nullopt}},
+  {NANOARROW_TIME_UNIT_NANO, {-4000000000, 4000000000, std::nullopt}},
+};
+
+INSTANTIATE_TEST_SUITE_P(PostgresCopyWriteDuration,
+                         PostgresCopyWriteDurationTest,
+                         testing::ValuesIn(duration_params));
+
+// COPY (SELECT CAST("col" AS TEXT) AS "col" FROM (  VALUES ('abc'), ('1234'),
+// (NULL::text)) AS drvd("col")) TO STDOUT WITH (FORMAT binary);
+static uint8_t kTestPgCopyText[] = {
+    0x50, 0x47, 0x43, 0x4f, 0x50, 0x59, 0x0a, 0xff, 0x0d, 0x0a, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+    0x03, 0x61, 0x62, 0x63, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04, 0x31, 0x32,
+    0x33, 0x34, 0x00, 0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+TEST(PostgresCopyUtilsTest, PostgresCopyReadText) {
+  ArrowBufferView data;
+  data.data.as_uint8 = kTestPgCopyText;
+  data.size_bytes = sizeof(kTestPgCopyText);
+
+  auto col_type = PostgresType(PostgresTypeId::kText);
+  PostgresType input_type(PostgresTypeId::kRecord);
+  input_type.AppendChild("col", col_type);
+
+  PostgresCopyStreamTester tester;
+  ASSERT_EQ(tester.Init(input_type), NANOARROW_OK);
+  ASSERT_EQ(tester.ReadAll(&data), ENODATA);
+  ASSERT_EQ(data.data.as_uint8 - kTestPgCopyText, sizeof(kTestPgCopyText));
+  ASSERT_EQ(data.size_bytes, 0);
+
+  nanoarrow::UniqueArray array;
+  ASSERT_EQ(tester.GetArray(array.get()), NANOARROW_OK);
+  ASSERT_EQ(array->length, 3);
+  ASSERT_EQ(array->n_children, 1);
+
+  auto validity = reinterpret_cast<const uint8_t*>(array->children[0]->buffers[0]);
+  auto offsets = reinterpret_cast<const int32_t*>(array->children[0]->buffers[1]);
+  auto data_buffer = reinterpret_cast<const char*>(array->children[0]->buffers[2]);
+  ASSERT_NE(validity, nullptr);
+  ASSERT_NE(data_buffer, nullptr);
+
+  ASSERT_TRUE(ArrowBitGet(validity, 0));
+  ASSERT_TRUE(ArrowBitGet(validity, 1));
+  ASSERT_FALSE(ArrowBitGet(validity, 2));
+
+  ASSERT_EQ(offsets[0], 0);
+  ASSERT_EQ(offsets[1], 3);
+  ASSERT_EQ(offsets[2], 7);
+  ASSERT_EQ(offsets[3], 7);
+
+  ASSERT_EQ(std::string(data_buffer + 0, 3), "abc");
+  ASSERT_EQ(std::string(data_buffer + 3, 4), "1234");
+}
+
+TEST(PostgresCopyUtilsTest, PostgresCopyWriteString) {
+  adbc_validation::Handle<struct ArrowSchema> schema;
+  adbc_validation::Handle<struct ArrowArray> array;
+  struct ArrowError na_error;
+  ASSERT_EQ(adbc_validation::MakeSchema(&schema.value, {{"col", NANOARROW_TYPE_STRING}}),
+            ADBC_STATUS_OK);
+  ASSERT_EQ(adbc_validation::MakeBatch<std::string>(
+                &schema.value, &array.value, &na_error, {"abc", "1234", std::nullopt}),
+            ADBC_STATUS_OK);
+
+  PostgresCopyStreamWriteTester tester;
+  ASSERT_EQ(tester.Init(&schema.value, &array.value), NANOARROW_OK);
+  ASSERT_EQ(tester.WriteAll(nullptr), ENODATA);
+
+  const struct ArrowBuffer buf = tester.WriteBuffer();
+  // The last 2 bytes of a message can be transmitted via PQputCopyData
+  // so no need to test those bytes from the Writer
+  constexpr size_t buf_size = sizeof(kTestPgCopyText) - 2;
+  ASSERT_EQ(buf.size_bytes, buf_size);
+  for (size_t i = 0; i < buf_size; i++) {
+    ASSERT_EQ(buf.data[i], kTestPgCopyText[i]);
+  }
+}
+
+TEST(PostgresCopyUtilsTest, PostgresCopyWriteLargeString) {
+  adbc_validation::Handle<struct ArrowSchema> schema;
+  adbc_validation::Handle<struct ArrowArray> array;
+  struct ArrowError na_error;
+  ASSERT_EQ(
+      adbc_validation::MakeSchema(&schema.value, {{"col", NANOARROW_TYPE_LARGE_STRING}}),
+      ADBC_STATUS_OK);
+  ASSERT_EQ(adbc_validation::MakeBatch<std::string>(
+                &schema.value, &array.value, &na_error, {"abc", "1234", std::nullopt}),
+            ADBC_STATUS_OK);
+
+  PostgresCopyStreamWriteTester tester;
+  ASSERT_EQ(tester.Init(&schema.value, &array.value), NANOARROW_OK);
+  ASSERT_EQ(tester.WriteAll(nullptr), ENODATA);
+
+  const struct ArrowBuffer buf = tester.WriteBuffer();
+  // The last 2 bytes of a message can be transmitted via PQputCopyData
+  // so no need to test those bytes from the Writer
+  constexpr size_t buf_size = sizeof(kTestPgCopyText) - 2;
+  ASSERT_EQ(buf.size_bytes, buf_size);
+  for (size_t i = 0; i < buf_size; i++) {
+    ASSERT_EQ(buf.data[i], kTestPgCopyText[i]);
+  }
+}
+
+// COPY (SELECT CAST("col" AS BYTEA) AS "col" FROM (  VALUES (''), ('\x0001'),
+// ('\x01020304'), ('\xFEFF'), (NULL)) AS drvd("col")) TO STDOUT
+// WITH (FORMAT binary);
+static uint8_t kTestPgCopyBinary[] = {
+    0x50, 0x47, 0x43, 0x4f, 0x50, 0x59, 0x0a, 0xff, 0x0d, 0x0a, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04,
+    0x01, 0x02, 0x03, 0x04, 0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0xfe, 0xff,
+    0x00, 0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+TEST(PostgresCopyUtilsTest, PostgresCopyReadBinary) {
+  ArrowBufferView data;
+  data.data.as_uint8 = kTestPgCopyBinary;
+  data.size_bytes = sizeof(kTestPgCopyBinary);
+
+  auto col_type = PostgresType(PostgresTypeId::kBytea);
+  PostgresType input_type(PostgresTypeId::kRecord);
+  input_type.AppendChild("col", col_type);
+
+  PostgresCopyStreamTester tester;
+  ASSERT_EQ(tester.Init(input_type), NANOARROW_OK);
+  ASSERT_EQ(tester.ReadAll(&data), ENODATA);
+  ASSERT_EQ(data.data.as_uint8 - kTestPgCopyBinary, sizeof(kTestPgCopyBinary));
+  ASSERT_EQ(data.size_bytes, 0);
+
+  nanoarrow::UniqueArray array;
+  ASSERT_EQ(tester.GetArray(array.get()), NANOARROW_OK);
+  ASSERT_EQ(array->length, 5);
+  ASSERT_EQ(array->n_children, 1);
+
+  auto validity = reinterpret_cast<const uint8_t*>(array->children[0]->buffers[0]);
+  auto offsets = reinterpret_cast<const int32_t*>(array->children[0]->buffers[1]);
+  auto data_buffer = reinterpret_cast<const uint8_t*>(array->children[0]->buffers[2]);
+  ASSERT_NE(validity, nullptr);
+  ASSERT_NE(data_buffer, nullptr);
+
+  ASSERT_TRUE(ArrowBitGet(validity, 0));
+  ASSERT_TRUE(ArrowBitGet(validity, 1));
+  ASSERT_TRUE(ArrowBitGet(validity, 2));
+  ASSERT_TRUE(ArrowBitGet(validity, 3));
+  ASSERT_FALSE(ArrowBitGet(validity, 4));
+
+  ASSERT_EQ(offsets[0], 0);
+  ASSERT_EQ(offsets[1], 0);
+  ASSERT_EQ(offsets[2], 2);
+  ASSERT_EQ(offsets[3], 6);
+  ASSERT_EQ(offsets[4], 8);
+  ASSERT_EQ(offsets[5], 8);
+
+  ASSERT_EQ(data_buffer[0], 0x00);
+  ASSERT_EQ(data_buffer[1], 0x01);
+  ASSERT_EQ(data_buffer[2], 0x01);
+  ASSERT_EQ(data_buffer[3], 0x02);
+  ASSERT_EQ(data_buffer[4], 0x03);
+  ASSERT_EQ(data_buffer[5], 0x04);
+  ASSERT_EQ(data_buffer[6], 0xfe);
+  ASSERT_EQ(data_buffer[7], 0xff);
+}
+
+TEST(PostgresCopyUtilsTest, PostgresCopyWriteBinary) {
+  adbc_validation::Handle<struct ArrowSchema> schema;
+  adbc_validation::Handle<struct ArrowArray> array;
+  struct ArrowError na_error;
+  ASSERT_EQ(adbc_validation::MakeSchema(&schema.value, {{"col", NANOARROW_TYPE_BINARY}}),
+            ADBC_STATUS_OK);
+  ASSERT_EQ(adbc_validation::MakeBatch<std::vector<std::byte>>(
+            &schema.value, &array.value, &na_error,
+            {
+              std::vector<std::byte>{},
+              std::vector<std::byte>{std::byte{0x00}, std::byte{0x01}},
+              std::vector<std::byte>{
+                std::byte{0x01}, std::byte{0x02}, std::byte{0x03}, std::byte{0x04}
+              },
+              std::vector<std::byte>{std::byte{0xfe}, std::byte{0xff}},
+              std::nullopt}),
+            ADBC_STATUS_OK);
+
+  PostgresCopyStreamWriteTester tester;
+  ASSERT_EQ(tester.Init(&schema.value, &array.value), NANOARROW_OK);
+  ASSERT_EQ(tester.WriteAll(nullptr), ENODATA);
+
+  const struct ArrowBuffer buf = tester.WriteBuffer();
+  // The last 2 bytes of a message can be transmitted via PQputCopyData
+  // so no need to test those bytes from the Writer
+  constexpr size_t buf_size = sizeof(kTestPgCopyBinary) - 2;
+  ASSERT_EQ(buf.size_bytes, buf_size);
+  for (size_t i = 0; i < buf_size; i++) {
+    ASSERT_EQ(buf.data[i], kTestPgCopyBinary[i]) << "failure at index " << i;
+  }
+}
+
+
+// COPY (SELECT CAST("col" AS INTEGER ARRAY) AS "col" FROM (  VALUES ('{-123, -1}'), ('{0,
+// 1, 123}'), (NULL)) AS drvd("col")) TO STDOUT WITH (FORMAT binary);
+static uint8_t kTestPgCopyIntegerArray[] = {
+    0x50, 0x47, 0x43, 0x4f, 0x50, 0x59, 0x0a, 0xff, 0x0d, 0x0a, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x24, 0x00, 0x00, 0x00,
+    0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x17, 0x00, 0x00, 0x00, 0x02, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04, 0xff, 0xff, 0xff, 0x85, 0x00, 0x00, 0x00,
+    0x04, 0xff, 0xff, 0xff, 0xff, 0x00, 0x01, 0x00, 0x00, 0x00, 0x2c, 0x00, 0x00, 0x00,
+    0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x17, 0x00, 0x00, 0x00, 0x03, 0x00,
+    0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x04, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0x7b, 0x00,
+    0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+TEST(PostgresCopyUtilsTest, PostgresCopyReadArray) {
+  ArrowBufferView data;
+  data.data.as_uint8 = kTestPgCopyIntegerArray;
+  data.size_bytes = sizeof(kTestPgCopyIntegerArray);
+
+  auto col_type = PostgresType(PostgresTypeId::kInt4).Array();
+  PostgresType input_type(PostgresTypeId::kRecord);
+  input_type.AppendChild("col", col_type);
+
+  PostgresCopyStreamTester tester;
+  ASSERT_EQ(tester.Init(input_type), NANOARROW_OK);
+  ASSERT_EQ(tester.ReadAll(&data), ENODATA);
+  ASSERT_EQ(data.data.as_uint8 - kTestPgCopyIntegerArray,
+            sizeof(kTestPgCopyIntegerArray));
+  ASSERT_EQ(data.size_bytes, 0);
+
+  nanoarrow::UniqueArray array;
+  ASSERT_EQ(tester.GetArray(array.get()), NANOARROW_OK);
+  ASSERT_EQ(array->length, 3);
+  ASSERT_EQ(array->n_children, 1);
+  ASSERT_EQ(array->children[0]->n_children, 1);
+  ASSERT_EQ(array->children[0]->children[0]->length, 5);
+
+  auto validity = reinterpret_cast<const uint8_t*>(array->children[0]->buffers[0]);
+  auto offsets = reinterpret_cast<const int32_t*>(array->children[0]->buffers[1]);
+  auto data_buffer =
+      reinterpret_cast<const int32_t*>(array->children[0]->children[0]->buffers[1]);
+  ASSERT_NE(validity, nullptr);
+  ASSERT_NE(data_buffer, nullptr);
+
+  ASSERT_TRUE(ArrowBitGet(validity, 0));
+  ASSERT_TRUE(ArrowBitGet(validity, 1));
+  ASSERT_FALSE(ArrowBitGet(validity, 2));
+
+  ASSERT_EQ(offsets[0], 0);
+  ASSERT_EQ(offsets[1], 2);
+  ASSERT_EQ(offsets[2], 5);
+  ASSERT_EQ(offsets[3], 5);
+
+  ASSERT_EQ(data_buffer[0], -123);
+  ASSERT_EQ(data_buffer[1], -1);
+  ASSERT_EQ(data_buffer[2], 0);
+  ASSERT_EQ(data_buffer[3], 1);
+  ASSERT_EQ(data_buffer[4], 123);
+}
+
+// CREATE TYPE custom_record AS (nested1 integer, nested2 double precision);
+// COPY (SELECT CAST("col" AS custom_record) AS "col" FROM (  VALUES ('(123, 456.789)'),
+// ('(12, 345.678)'), (NULL)) AS drvd("col")) TO STDOUT WITH (FORMAT binary);
+static uint8_t kTestPgCopyCustomRecord[] = {
+    0x50, 0x47, 0x43, 0x4f, 0x50, 0x59, 0x0a, 0xff, 0x0d, 0x0a, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x20, 0x00,
+    0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x17, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00,
+    0x00, 0x7b, 0x00, 0x00, 0x02, 0xbd, 0x00, 0x00, 0x00, 0x08, 0x40, 0x7c, 0x8c,
+    0x9f, 0xbe, 0x76, 0xc8, 0xb4, 0x00, 0x01, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00,
+    0x00, 0x02, 0x00, 0x00, 0x00, 0x17, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00,
+    0x0c, 0x00, 0x00, 0x02, 0xbd, 0x00, 0x00, 0x00, 0x08, 0x40, 0x75, 0x9a, 0xd9,
+    0x16, 0x87, 0x2b, 0x02, 0x00, 0x01, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
+
+TEST(PostgresCopyUtilsTest, PostgresCopyReadCustomRecord) {
+  ArrowBufferView data;
+  data.data.as_uint8 = kTestPgCopyCustomRecord;
+  data.size_bytes = sizeof(kTestPgCopyCustomRecord);
+
+  auto col_type = PostgresType(PostgresTypeId::kRecord);
+  col_type.AppendChild("nested1", PostgresType(PostgresTypeId::kInt4));
+  col_type.AppendChild("nested2", PostgresType(PostgresTypeId::kFloat8));
+  PostgresType input_type(PostgresTypeId::kRecord);
+  input_type.AppendChild("col", col_type);
+
+  PostgresCopyStreamTester tester;
+  ASSERT_EQ(tester.Init(input_type), NANOARROW_OK);
+  ASSERT_EQ(tester.ReadAll(&data), ENODATA);
+  ASSERT_EQ(data.data.as_uint8 - kTestPgCopyCustomRecord,
+            sizeof(kTestPgCopyCustomRecord));
+  ASSERT_EQ(data.size_bytes, 0);
+
+  nanoarrow::UniqueArray array;
+  ASSERT_EQ(tester.GetArray(array.get()), NANOARROW_OK);
+  ASSERT_EQ(array->length, 3);
+  ASSERT_EQ(array->n_children, 1);
+  ASSERT_EQ(array->children[0]->n_children, 2);
+  ASSERT_EQ(array->children[0]->children[0]->length, 3);
+  ASSERT_EQ(array->children[0]->children[1]->length, 3);
+
+  auto validity = reinterpret_cast<const uint8_t*>(array->children[0]->buffers[0]);
+  auto data_buffer1 =
+      reinterpret_cast<const int32_t*>(array->children[0]->children[0]->buffers[1]);
+  auto data_buffer2 =
+      reinterpret_cast<const double*>(array->children[0]->children[1]->buffers[1]);
+
+  ASSERT_TRUE(ArrowBitGet(validity, 0));
+  ASSERT_TRUE(ArrowBitGet(validity, 1));
+  ASSERT_FALSE(ArrowBitGet(validity, 2));
+
+  ASSERT_EQ(data_buffer1[0], 123);
+  ASSERT_EQ(data_buffer1[1], 12);
+  ASSERT_EQ(data_buffer1[2], 0);
+
+  ASSERT_DOUBLE_EQ(data_buffer2[0], 456.789);
+  ASSERT_DOUBLE_EQ(data_buffer2[1], 345.678);
+  ASSERT_DOUBLE_EQ(data_buffer2[2], 0);
+}
+
+TEST(PostgresCopyUtilsTest, PostgresCopyWriteMultiBatch) {
+  // Regression test for https://github.com/apache/arrow-adbc/issues/1310
+  adbc_validation::Handle<struct ArrowSchema> schema;
+  adbc_validation::Handle<struct ArrowArray> array;
+  struct ArrowError na_error;
+  ASSERT_EQ(adbc_validation::MakeSchema(&schema.value, {{"col", NANOARROW_TYPE_INT32}}),
+            NANOARROW_OK);
+  ASSERT_EQ(adbc_validation::MakeBatch<int32_t>(&schema.value, &array.value, &na_error,
+                                                {-123, -1, 1, 123, std::nullopt}),
+            NANOARROW_OK);
+
+  PostgresCopyStreamWriteTester tester;
+  ASSERT_EQ(tester.Init(&schema.value, &array.value), NANOARROW_OK);
+  ASSERT_EQ(tester.WriteAll(nullptr), ENODATA);
+
+  struct ArrowBuffer buf = tester.WriteBuffer();
+  // The last 2 bytes of a message can be transmitted via PQputCopyData
+  // so no need to test those bytes from the Writer
+  size_t buf_size = sizeof(kTestPgCopyInteger) - 2;
+  ASSERT_EQ(buf.size_bytes, buf_size);
+  for (size_t i = 0; i < buf_size; i++) {
+    ASSERT_EQ(buf.data[i], kTestPgCopyInteger[i]);
+  }
+
+  tester.Rewind();
+  ASSERT_EQ(tester.WriteArray(&array.value, nullptr), ENODATA);
+
+  buf = tester.WriteBuffer();
+  // Ignore the header and footer
+  buf_size = sizeof(kTestPgCopyInteger) - 21;
+  ASSERT_EQ(buf.size_bytes, buf_size);
+  for (size_t i = 0; i < buf_size; i++) {
+    ASSERT_EQ(buf.data[i], kTestPgCopyInteger[i + 19]);
+  }
+}
+
+}  // namespace adbcpq

--- a/c/driver/netezza/postgres_type.h
+++ b/c/driver/netezza/postgres_type.h
@@ -1,0 +1,952 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cerrno>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <nanoarrow/nanoarrow.hpp>
+
+namespace adbcpq {
+
+// An enum of the types available in most Postgres pg_type tables
+enum class PostgresTypeId {
+  kUninitialized,
+  kAclitem,
+  kAnyarray,
+  kAnycompatiblearray,
+  kArray,
+  kBit,
+  kBool,
+  kBox,
+  kBpchar,
+  kBrinBloomSummary,
+  kBrinMinmaxMultiSummary,
+  kBytea,
+  kCash,
+  kChar,
+  kCidr,
+  kCid,
+  kCircle,
+  kCstring,
+  kDate,
+  kDomain,
+  kFloat4,
+  kFloat8,
+  kInet,
+  kInt2,
+  kInt2vector,
+  kInt4,
+  kInt8,
+  kInterval,
+  kJson,
+  kJsonb,
+  kJsonpath,
+  kLine,
+  kLseg,
+  kMacaddr,
+  kMacaddr8,
+  kMultirange,
+  kName,
+  kNumeric,
+  kOid,
+  kOidvector,
+  kPath,
+  kPgDdlCommand,
+  kPgDependencies,
+  kPgLsn,
+  kPgMcvList,
+  kPgNdistinct,
+  kPgNodeTree,
+  kPgSnapshot,
+  kPoint,
+  kPoly,
+  kRange,
+  kRecord,
+  kRegclass,
+  kRegcollation,
+  kRegconfig,
+  kRegdictionary,
+  kRegnamespace,
+  kRegoperator,
+  kRegoper,
+  kRegprocedure,
+  kRegproc,
+  kRegrole,
+  kRegtype,
+  kText,
+  kTid,
+  kTime,
+  kTimestamp,
+  kTimestamptz,
+  kTimetz,
+  kTsquery,
+  kTsvector,
+  kTxidSnapshot,
+  kUnknown,
+  kUuid,
+  kVarbit,
+  kVarchar,
+  kVoid,
+  kXid8,
+  kXid,
+  kXml,
+  kUserDefined
+};
+
+// Returns the receive function name as defined in the typrecieve column
+// of the pg_type table. This name is the one that gets used to look up
+// the PostgresTypeId.
+static inline const char* PostgresTyprecv(PostgresTypeId type_id);
+
+// Returns a likely typname value for a given PostgresTypeId. This is useful
+// for testing and error messages but may not be the actual value present
+// in the pg_type typname column.
+static inline const char* PostgresTypname(PostgresTypeId type_id);
+
+// A vector of all type IDs, optionally including the nested types PostgresTypeId::ARRAY,
+// PostgresTypeId::DOMAIN_, PostgresTypeId::RECORD, and PostgresTypeId::RANGE.
+static inline std::vector<PostgresTypeId> PostgresTypeIdAll(bool nested = true);
+
+class PostgresTypeResolver;
+
+// An abstraction of a (potentially nested and/or parameterized) Postgres
+// data type. This class is where default type conversion to/from Arrow
+// is defined. It is intentionally copyable.
+class PostgresType {
+ public:
+  explicit PostgresType(PostgresTypeId type_id) : oid_(0), type_id_(type_id) {}
+
+  PostgresType() : PostgresType(PostgresTypeId::kUninitialized) {}
+
+  void AppendChild(const std::string& field_name, const PostgresType& type) {
+    PostgresType child(type);
+    children_.push_back(child.WithFieldName(field_name));
+  }
+
+  PostgresType WithFieldName(const std::string& field_name) const {
+    PostgresType out(*this);
+    out.field_name_ = field_name;
+    return out;
+  }
+
+  PostgresType WithPgTypeInfo(uint32_t oid, const std::string& typname) const {
+    PostgresType out(*this);
+    out.oid_ = oid;
+    out.typname_ = typname;
+    return out;
+  }
+
+  PostgresType Array(uint32_t oid = 0, const std::string& typname = "") const {
+    PostgresType out(PostgresTypeId::kArray);
+    out.AppendChild("item", *this);
+    out.oid_ = oid;
+    out.typname_ = typname;
+    return out;
+  }
+
+  PostgresType Domain(uint32_t oid, const std::string& typname) {
+    return WithPgTypeInfo(oid, typname);
+  }
+
+  PostgresType Range(uint32_t oid = 0, const std::string& typname = "") const {
+    PostgresType out(PostgresTypeId::kRange);
+    out.AppendChild("item", *this);
+    out.oid_ = oid;
+    out.typname_ = typname;
+    return out;
+  }
+
+  uint32_t oid() const { return oid_; }
+  PostgresTypeId type_id() const { return type_id_; }
+  const std::string& typname() const { return typname_; }
+  const std::string& field_name() const { return field_name_; }
+  int64_t n_children() const { return static_cast<int64_t>(children_.size()); }
+  const PostgresType& child(int64_t i) const { return children_[i]; }
+
+  // Sets appropriate fields of an ArrowSchema that has been initialized using
+  // ArrowSchemaInit. This is a recursive operation (i.e., nested types will
+  // initialize and set the appropriate number of children). Returns NANOARROW_OK
+  // on success and perhaps ENOMEM if memory cannot be allocated. Types that
+  // do not have a corresponding Arrow type are returned as Binary with field
+  // metadata ADBC:posgresql:typname. These types can be represented as their
+  // binary COPY representation in the output.
+  ArrowErrorCode SetSchema(ArrowSchema* schema) const {
+    switch (type_id_) {
+      // ---- Primitive types --------------------
+      case PostgresTypeId::kBool:
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_BOOL));
+        break;
+      case PostgresTypeId::kInt2:
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_INT16));
+        break;
+      case PostgresTypeId::kInt4:
+      case PostgresTypeId::kOid:
+      case PostgresTypeId::kRegproc:
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_INT32));
+        break;
+      case PostgresTypeId::kInt8:
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_INT64));
+        break;
+      case PostgresTypeId::kFloat4:
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_FLOAT));
+        break;
+      case PostgresTypeId::kFloat8:
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_DOUBLE));
+        break;
+
+      // ---- Numeric/Decimal-------------------
+      case PostgresTypeId::kNumeric:
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_STRING));
+        break;
+
+      // ---- Binary/string --------------------
+      case PostgresTypeId::kChar:
+      case PostgresTypeId::kBpchar:
+      case PostgresTypeId::kVarchar:
+      case PostgresTypeId::kText:
+      case PostgresTypeId::kName:
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_STRING));
+        break;
+      case PostgresTypeId::kBytea:
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_BINARY));
+        break;
+
+      // ---- Temporal --------------------
+      case PostgresTypeId::kDate:
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_DATE32));
+        break;
+
+      case PostgresTypeId::kTime:
+        // We always return microsecond precision even if the type
+        // specifies differently
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetTypeDateTime(schema, NANOARROW_TYPE_TIME64,
+                                                           NANOARROW_TIME_UNIT_MICRO,
+                                                           /*timezone=*/nullptr));
+        break;
+
+      case PostgresTypeId::kTimestamp:
+        // We always return microsecond precision even if the type
+        // specifies differently
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetTypeDateTime(schema, NANOARROW_TYPE_TIMESTAMP,
+                                       NANOARROW_TIME_UNIT_MICRO, /*timezone=*/nullptr));
+        break;
+
+      case PostgresTypeId::kTimestamptz:
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetTypeDateTime(schema, NANOARROW_TYPE_TIMESTAMP,
+                                       NANOARROW_TIME_UNIT_MICRO, /*timezone=*/"UTC"));
+        break;
+
+      case PostgresTypeId::kInterval:
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetType(schema, NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO));
+        break;
+
+      // ---- Nested --------------------
+      case PostgresTypeId::kRecord:
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetTypeStruct(schema, n_children()));
+        for (int64_t i = 0; i < n_children(); i++) {
+          NANOARROW_RETURN_NOT_OK(children_[i].SetSchema(schema->children[i]));
+        }
+        break;
+
+      case PostgresTypeId::kArray:
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_LIST));
+        NANOARROW_RETURN_NOT_OK(children_[0].SetSchema(schema->children[0]));
+        break;
+
+      case PostgresTypeId::kUserDefined:
+      default: {
+        // For user-defined types or types we don't explicitly know how to deal with, we
+        // can still return the bytes postgres gives us and attach the type name as
+        // metadata
+        NANOARROW_RETURN_NOT_OK(ArrowSchemaSetType(schema, NANOARROW_TYPE_BINARY));
+        nanoarrow::UniqueBuffer buffer;
+        ArrowMetadataBuilderInit(buffer.get(), nullptr);
+        NANOARROW_RETURN_NOT_OK(ArrowMetadataBuilderAppend(
+            buffer.get(), ArrowCharView("ADBC:postgresql:typname"),
+            ArrowCharView(typname_.c_str())));
+        NANOARROW_RETURN_NOT_OK(
+            ArrowSchemaSetMetadata(schema, reinterpret_cast<char*>(buffer->data)));
+        break;
+      }
+    }
+
+    NANOARROW_RETURN_NOT_OK(ArrowSchemaSetName(schema, field_name_.c_str()));
+    return NANOARROW_OK;
+  }
+
+  static ArrowErrorCode FromSchema(const PostgresTypeResolver& resolver,
+                                   ArrowSchema* schema, PostgresType* out,
+                                   ArrowError* error);
+
+ private:
+  uint32_t oid_;
+  PostgresTypeId type_id_;
+  std::string typname_;
+  std::string field_name_;
+  std::vector<PostgresType> children_;
+};
+
+// Because type information is stored in a database's pg_type table, it can't
+// truly be resolved until runtime; however, querying the database's pg_type table
+// for every result is unlikely to be reasonable. This class is a cache of information
+// from the pg_type table with appropriate lookup tables to resolve a PostgresType
+// instance based on a oid (which is the information that libpq provides when
+// inspecting a result object). Types can be added/removed from the pg_type table
+// via SQL, so this cache may need to be periodically refreshed.
+class PostgresTypeResolver {
+ public:
+  struct Item {
+    uint32_t oid;
+    const char* typname;
+    const char* typreceive;
+    uint32_t child_oid;
+    uint32_t base_oid;
+    uint32_t class_oid;
+  };
+
+  PostgresTypeResolver() : base_(AllBase()) {}
+
+  // Place a resolved copy of a PostgresType with the appropriate oid in type_out
+  // if NANOARROW_OK is returned or place a null-terminated error message into error
+  // otherwise.
+  ArrowErrorCode Find(uint32_t oid, PostgresType* type_out, ArrowError* error) const {
+    auto result = mapping_.find(oid);
+    if (result == mapping_.end()) {
+      ArrowErrorSet(error, "Postgres type with oid %ld not found",
+                    static_cast<long>(oid));  // NOLINT(runtime/int)
+      return EINVAL;
+    }
+
+    *type_out = (*result).second;
+    return NANOARROW_OK;
+  }
+
+  ArrowErrorCode FindArray(uint32_t child_oid, PostgresType* type_out,
+                           ArrowError* error) const {
+    auto array_oid_lookup = array_mapping_.find(child_oid);
+    if (array_oid_lookup == array_mapping_.end()) {
+      ArrowErrorSet(error, "Postgres array type with child oid %ld not found",
+                    static_cast<long>(child_oid));  // NOLINT(runtime/int)
+      return EINVAL;
+    }
+
+    return Find(array_oid_lookup->second, type_out, error);
+  }
+
+  // Resolve the oid for a given type_id. Returns 0 if the oid cannot be
+  // resolved.
+  uint32_t GetOID(PostgresTypeId type_id) const {
+    auto result = reverse_mapping_.find(static_cast<int32_t>(type_id));
+    if (result == reverse_mapping_.end()) {
+      return 0;
+    } else {
+      return result->second;
+    }
+  }
+
+  // Insert a type into this resolver. Returns NANOARROW_OK on success
+  // or places a null-terminated error message into error otherwise. The order
+  // of Inserts matters: Non-array types must be inserted before the corresponding
+  // array types and class definitions must be inserted before the corresponding
+  // class type using InsertClass().
+  ArrowErrorCode Insert(const Item& item, ArrowError* error) {
+    auto result = base_.find(item.typreceive);
+    PostgresType base;
+
+    if (result == base_.end()) {
+      // This occurs when a user-defined type has defined a custom receive function
+      // (e.g., PostGIS/geometry). The only way these types can be supported is
+      // by returning binary unless we hard-code support for some extensions.
+      base = PostgresType(PostgresTypeId::kUserDefined);
+    } else {
+      base = result->second;
+    }
+
+    PostgresType type = base.WithPgTypeInfo(item.oid, item.typname);
+
+    switch (base.type_id()) {
+      case PostgresTypeId::kArray: {
+        PostgresType child;
+        NANOARROW_RETURN_NOT_OK(Find(item.child_oid, &child, error));
+        mapping_.insert({item.oid, child.Array(item.oid, item.typname)});
+        reverse_mapping_.insert({static_cast<int32_t>(base.type_id()), item.oid});
+        array_mapping_.insert({child.oid(), item.oid});
+        break;
+      }
+
+      case PostgresTypeId::kRecord: {
+        std::vector<std::pair<std::string, uint32_t>> child_desc;
+        NANOARROW_RETURN_NOT_OK(ResolveClass(item.class_oid, &child_desc, error));
+
+        PostgresType out(PostgresTypeId::kRecord);
+        for (const auto& child_item : child_desc) {
+          PostgresType child;
+          NANOARROW_RETURN_NOT_OK(Find(child_item.second, &child, error));
+          out.AppendChild(child_item.first, child);
+        }
+
+        mapping_.insert({item.oid, out.WithPgTypeInfo(item.oid, item.typname)});
+        reverse_mapping_.insert({static_cast<int32_t>(base.type_id()), item.oid});
+        break;
+      }
+
+      case PostgresTypeId::kDomain: {
+        PostgresType base_type;
+        NANOARROW_RETURN_NOT_OK(Find(item.base_oid, &base_type, error));
+        mapping_.insert({item.oid, base_type.Domain(item.oid, item.typname)});
+        reverse_mapping_.insert({static_cast<int32_t>(base.type_id()), item.oid});
+        break;
+      }
+
+      case PostgresTypeId::kRange: {
+        PostgresType base_type;
+        NANOARROW_RETURN_NOT_OK(Find(item.base_oid, &base_type, error));
+        mapping_.insert({item.oid, base_type.Range(item.oid, item.typname)});
+        reverse_mapping_.insert({static_cast<int32_t>(base.type_id()), item.oid});
+        break;
+      }
+
+      default:
+        mapping_.insert({item.oid, type});
+        reverse_mapping_.insert({static_cast<int32_t>(base.type_id()), item.oid});
+        break;
+    }
+
+    return NANOARROW_OK;
+  }
+
+  // Insert a class definition. For the purposes of resolving a PostgresType
+  // instance, this is simply a vector of field_name: oid tuples. The specified
+  // OIDs need not have already been inserted into the type resolver. This
+  // information can be found in the pg_attribute table (attname and atttypoid,
+  // respectively).
+  void InsertClass(uint32_t oid,
+                   const std::vector<std::pair<std::string, uint32_t>>& cls) {
+    classes_.insert({oid, cls});
+  }
+
+ private:
+  std::unordered_map<uint32_t, PostgresType> mapping_;
+  // We can't use PostgresTypeId as an unordered map key because there is no
+  // built-in hasher for an enum on gcc 4.8 (i.e., R 3.6 on Windows).
+  std::unordered_map<int32_t, uint32_t> reverse_mapping_;
+  std::unordered_map<uint32_t, uint32_t> array_mapping_;
+  std::unordered_map<uint32_t, std::vector<std::pair<std::string, uint32_t>>> classes_;
+  std::unordered_map<std::string, PostgresType> base_;
+
+  ArrowErrorCode ResolveClass(uint32_t oid,
+                              std::vector<std::pair<std::string, uint32_t>>* out,
+                              ArrowError* error) {
+    auto result = classes_.find(oid);
+    if (result == classes_.end()) {
+      ArrowErrorSet(error, "Class definition with oid %ld not found",
+                    static_cast<long>(oid));  // NOLINT(runtime/int)
+      return EINVAL;
+    }
+
+    *out = result->second;
+    return NANOARROW_OK;
+  }
+
+  // Returns a sentinel PostgresType instance for each type and builds a lookup
+  // table based on the receive function name.
+  static std::unordered_map<std::string, PostgresType> AllBase() {
+    std::unordered_map<std::string, PostgresType> out;
+    for (PostgresTypeId type_id : PostgresTypeIdAll()) {
+      PostgresType type(type_id);
+      out.insert(
+          {PostgresTyprecv(type_id), type.WithPgTypeInfo(0, PostgresTypname(type_id))});
+    }
+
+    return out;
+  }
+};
+
+inline ArrowErrorCode PostgresType::FromSchema(const PostgresTypeResolver& resolver,
+                                               ArrowSchema* schema, PostgresType* out,
+                                               ArrowError* error) {
+  ArrowSchemaView schema_view;
+  NANOARROW_RETURN_NOT_OK(ArrowSchemaViewInit(&schema_view, schema, error));
+
+  switch (schema_view.type) {
+    case NANOARROW_TYPE_BOOL:
+      return resolver.Find(resolver.GetOID(PostgresTypeId::kBool), out, error);
+    case NANOARROW_TYPE_INT8:
+    case NANOARROW_TYPE_UINT8:
+    case NANOARROW_TYPE_INT16:
+      return resolver.Find(resolver.GetOID(PostgresTypeId::kInt2), out, error);
+    case NANOARROW_TYPE_UINT16:
+    case NANOARROW_TYPE_INT32:
+      return resolver.Find(resolver.GetOID(PostgresTypeId::kInt4), out, error);
+    case NANOARROW_TYPE_UINT32:
+    case NANOARROW_TYPE_INT64:
+      return resolver.Find(resolver.GetOID(PostgresTypeId::kInt8), out, error);
+    case NANOARROW_TYPE_FLOAT:
+      return resolver.Find(resolver.GetOID(PostgresTypeId::kFloat4), out, error);
+    case NANOARROW_TYPE_DOUBLE:
+      return resolver.Find(resolver.GetOID(PostgresTypeId::kFloat8), out, error);
+    case NANOARROW_TYPE_STRING:
+      return resolver.Find(resolver.GetOID(PostgresTypeId::kText), out, error);
+    case NANOARROW_TYPE_BINARY:
+    case NANOARROW_TYPE_FIXED_SIZE_BINARY:
+      return resolver.Find(resolver.GetOID(PostgresTypeId::kBytea), out, error);
+    case NANOARROW_TYPE_LIST:
+    case NANOARROW_TYPE_LARGE_LIST:
+    case NANOARROW_TYPE_FIXED_SIZE_LIST: {
+      PostgresType child;
+      NANOARROW_RETURN_NOT_OK(
+          PostgresType::FromSchema(resolver, schema->children[0], &child, error));
+      return resolver.FindArray(child.oid(), out, error);
+    }
+    case NANOARROW_TYPE_DICTIONARY:
+      // Dictionary arrays always resolve to the dictionary type when binding or ingesting
+      return PostgresType::FromSchema(resolver, schema->dictionary, out, error);
+
+    default:
+      ArrowErrorSet(error, "Can't map Arrow type '%s' to Postgres type",
+                    ArrowTypeString(schema_view.type));
+      return ENOTSUP;
+  }
+}
+
+static inline const char* PostgresTyprecv(PostgresTypeId type_id) {
+  switch (type_id) {
+    case PostgresTypeId::kAclitem:
+      return "aclitem_recv";
+    case PostgresTypeId::kAnyarray:
+      return "anyarray_recv";
+    case PostgresTypeId::kAnycompatiblearray:
+      return "anycompatiblearray_recv";
+    case PostgresTypeId::kArray:
+      return "array_recv";
+    case PostgresTypeId::kBit:
+      return "bit_recv";
+    case PostgresTypeId::kBool:
+      return "boolrecv";
+    case PostgresTypeId::kBox:
+      return "box_recv";
+    case PostgresTypeId::kBpchar:
+      return "bpcharrecv";
+    case PostgresTypeId::kBrinBloomSummary:
+      return "brin_bloom_summary_recv";
+    case PostgresTypeId::kBrinMinmaxMultiSummary:
+      return "brin_minmax_multi_summary_recv";
+    case PostgresTypeId::kBytea:
+      return "bytearecv";
+    case PostgresTypeId::kCash:
+      return "cash_recv";
+    case PostgresTypeId::kChar:
+      return "charrecv";
+    case PostgresTypeId::kCidr:
+      return "cidr_recv";
+    case PostgresTypeId::kCid:
+      return "cidrecv";
+    case PostgresTypeId::kCircle:
+      return "circle_recv";
+    case PostgresTypeId::kCstring:
+      return "cstring_recv";
+    case PostgresTypeId::kDate:
+      return "date_recv";
+    case PostgresTypeId::kDomain:
+      return "domain_recv";
+    case PostgresTypeId::kFloat4:
+      return "float4recv";
+    case PostgresTypeId::kFloat8:
+      return "float8recv";
+    case PostgresTypeId::kInet:
+      return "inet_recv";
+    case PostgresTypeId::kInt2:
+      return "int2recv";
+    case PostgresTypeId::kInt2vector:
+      return "int2vectorrecv";
+    case PostgresTypeId::kInt4:
+      return "int4recv";
+    case PostgresTypeId::kInt8:
+      return "int8recv";
+    case PostgresTypeId::kInterval:
+      return "interval_recv";
+    case PostgresTypeId::kJson:
+      return "json_recv";
+    case PostgresTypeId::kJsonb:
+      return "jsonb_recv";
+    case PostgresTypeId::kJsonpath:
+      return "jsonpath_recv";
+    case PostgresTypeId::kLine:
+      return "line_recv";
+    case PostgresTypeId::kLseg:
+      return "lseg_recv";
+    case PostgresTypeId::kMacaddr:
+      return "macaddr_recv";
+    case PostgresTypeId::kMacaddr8:
+      return "macaddr8_recv";
+    case PostgresTypeId::kMultirange:
+      return "multirange_recv";
+    case PostgresTypeId::kName:
+      return "namerecv";
+    case PostgresTypeId::kNumeric:
+      return "numeric_recv";
+    case PostgresTypeId::kOid:
+      return "oidrecv";
+    case PostgresTypeId::kOidvector:
+      return "oidvectorrecv";
+    case PostgresTypeId::kPath:
+      return "path_recv";
+    case PostgresTypeId::kPgNodeTree:
+      return "pg_node_tree_recv";
+    case PostgresTypeId::kPgNdistinct:
+      return "pg_ndistinct_recv";
+    case PostgresTypeId::kPgDependencies:
+      return "pg_dependencies_recv";
+    case PostgresTypeId::kPgLsn:
+      return "pg_lsn_recv";
+    case PostgresTypeId::kPgMcvList:
+      return "pg_mcv_list_recv";
+    case PostgresTypeId::kPgDdlCommand:
+      return "pg_ddl_command_recv";
+    case PostgresTypeId::kPgSnapshot:
+      return "pg_snapshot_recv";
+    case PostgresTypeId::kPoint:
+      return "point_recv";
+    case PostgresTypeId::kPoly:
+      return "poly_recv";
+    case PostgresTypeId::kRange:
+      return "range_recv";
+    case PostgresTypeId::kRecord:
+      return "record_recv";
+    case PostgresTypeId::kRegclass:
+      return "regclassrecv";
+    case PostgresTypeId::kRegcollation:
+      return "regcollationrecv";
+    case PostgresTypeId::kRegconfig:
+      return "regconfigrecv";
+    case PostgresTypeId::kRegdictionary:
+      return "regdictionaryrecv";
+    case PostgresTypeId::kRegnamespace:
+      return "regnamespacerecv";
+    case PostgresTypeId::kRegoperator:
+      return "regoperatorrecv";
+    case PostgresTypeId::kRegoper:
+      return "regoperrecv";
+    case PostgresTypeId::kRegprocedure:
+      return "regprocedurerecv";
+    case PostgresTypeId::kRegproc:
+      return "regprocrecv";
+    case PostgresTypeId::kRegrole:
+      return "regrolerecv";
+    case PostgresTypeId::kRegtype:
+      return "regtyperecv";
+    case PostgresTypeId::kText:
+      return "textrecv";
+    case PostgresTypeId::kTid:
+      return "tidrecv";
+    case PostgresTypeId::kTime:
+      return "time_recv";
+    case PostgresTypeId::kTimestamp:
+      return "timestamp_recv";
+    case PostgresTypeId::kTimestamptz:
+      return "timestamptz_recv";
+    case PostgresTypeId::kTimetz:
+      return "timetz_recv";
+    case PostgresTypeId::kTsquery:
+      return "tsqueryrecv";
+    case PostgresTypeId::kTsvector:
+      return "tsvectorrecv";
+    case PostgresTypeId::kTxidSnapshot:
+      return "txid_snapshot_recv";
+    case PostgresTypeId::kUnknown:
+      return "unknownrecv";
+    case PostgresTypeId::kUuid:
+      return "uuid_recv";
+    case PostgresTypeId::kVarbit:
+      return "varbit_recv";
+    case PostgresTypeId::kVarchar:
+      return "varcharrecv";
+    case PostgresTypeId::kVoid:
+      return "void_recv";
+    case PostgresTypeId::kXid8:
+      return "xid8recv";
+    case PostgresTypeId::kXid:
+      return "xidrecv";
+    case PostgresTypeId::kXml:
+      return "xml_recv";
+    default:
+      return "";
+  }
+}
+
+static inline const char* PostgresTypname(PostgresTypeId type_id) {
+  switch (type_id) {
+    case PostgresTypeId::kAclitem:
+      return "aclitem";
+    case PostgresTypeId::kAnyarray:
+      return "anyarray";
+    case PostgresTypeId::kAnycompatiblearray:
+      return "anycompatiblearray";
+    case PostgresTypeId::kArray:
+      return "array";
+    case PostgresTypeId::kBit:
+      return "bit";
+    case PostgresTypeId::kBool:
+      return "bool";
+    case PostgresTypeId::kBox:
+      return "box";
+    case PostgresTypeId::kBpchar:
+      return "bpchar";
+    case PostgresTypeId::kBrinBloomSummary:
+      return "brin_bloom_summary";
+    case PostgresTypeId::kBrinMinmaxMultiSummary:
+      return "brin_minmax_multi_summary";
+    case PostgresTypeId::kBytea:
+      return "bytea";
+    case PostgresTypeId::kCash:
+      return "cash";
+    case PostgresTypeId::kChar:
+      return "char";
+    case PostgresTypeId::kCidr:
+      return "cidr";
+    case PostgresTypeId::kCid:
+      return "cid";
+    case PostgresTypeId::kCircle:
+      return "circle";
+    case PostgresTypeId::kCstring:
+      return "cstring";
+    case PostgresTypeId::kDate:
+      return "date";
+    case PostgresTypeId::kDomain:
+      return "domain";
+    case PostgresTypeId::kFloat4:
+      return "float4";
+    case PostgresTypeId::kFloat8:
+      return "float8";
+    case PostgresTypeId::kInet:
+      return "inet";
+    case PostgresTypeId::kInt2:
+      return "int2";
+    case PostgresTypeId::kInt2vector:
+      return "int2vector";
+    case PostgresTypeId::kInt4:
+      return "int4";
+    case PostgresTypeId::kInt8:
+      return "int8";
+    case PostgresTypeId::kInterval:
+      return "interval";
+    case PostgresTypeId::kJson:
+      return "json";
+    case PostgresTypeId::kJsonb:
+      return "jsonb";
+    case PostgresTypeId::kJsonpath:
+      return "jsonpath";
+    case PostgresTypeId::kLine:
+      return "line";
+    case PostgresTypeId::kLseg:
+      return "lseg";
+    case PostgresTypeId::kMacaddr:
+      return "macaddr";
+    case PostgresTypeId::kMacaddr8:
+      return "macaddr8";
+    case PostgresTypeId::kMultirange:
+      return "multirange";
+    case PostgresTypeId::kName:
+      return "name";
+    case PostgresTypeId::kNumeric:
+      return "numeric";
+    case PostgresTypeId::kOid:
+      return "oid";
+    case PostgresTypeId::kOidvector:
+      return "oidvector";
+    case PostgresTypeId::kPath:
+      return "path";
+    case PostgresTypeId::kPgNodeTree:
+      return "pg_node_tree";
+    case PostgresTypeId::kPgNdistinct:
+      return "pg_ndistinct";
+    case PostgresTypeId::kPgDependencies:
+      return "pg_dependencies";
+    case PostgresTypeId::kPgLsn:
+      return "pg_lsn";
+    case PostgresTypeId::kPgMcvList:
+      return "pg_mcv_list";
+    case PostgresTypeId::kPgDdlCommand:
+      return "pg_ddl_command";
+    case PostgresTypeId::kPgSnapshot:
+      return "pg_snapshot";
+    case PostgresTypeId::kPoint:
+      return "point";
+    case PostgresTypeId::kPoly:
+      return "poly";
+    case PostgresTypeId::kRange:
+      return "range";
+    case PostgresTypeId::kRecord:
+      return "record";
+    case PostgresTypeId::kRegclass:
+      return "regclass";
+    case PostgresTypeId::kRegcollation:
+      return "regcollation";
+    case PostgresTypeId::kRegconfig:
+      return "regconfig";
+    case PostgresTypeId::kRegdictionary:
+      return "regdictionary";
+    case PostgresTypeId::kRegnamespace:
+      return "regnamespace";
+    case PostgresTypeId::kRegoperator:
+      return "regoperator";
+    case PostgresTypeId::kRegoper:
+      return "regoper";
+    case PostgresTypeId::kRegprocedure:
+      return "regprocedure";
+    case PostgresTypeId::kRegproc:
+      return "regproc";
+    case PostgresTypeId::kRegrole:
+      return "regrole";
+    case PostgresTypeId::kRegtype:
+      return "regtype";
+    case PostgresTypeId::kText:
+      return "text";
+    case PostgresTypeId::kTid:
+      return "tid";
+    case PostgresTypeId::kTime:
+      return "time";
+    case PostgresTypeId::kTimestamp:
+      return "timestamp";
+    case PostgresTypeId::kTimestamptz:
+      return "timestamptz";
+    case PostgresTypeId::kTimetz:
+      return "timetz";
+    case PostgresTypeId::kTsquery:
+      return "tsquery";
+    case PostgresTypeId::kTsvector:
+      return "tsvector";
+    case PostgresTypeId::kTxidSnapshot:
+      return "txid_snapshot";
+    case PostgresTypeId::kUnknown:
+      return "unknown";
+    case PostgresTypeId::kUuid:
+      return "uuid";
+    case PostgresTypeId::kVarbit:
+      return "varbit";
+    case PostgresTypeId::kVarchar:
+      return "varchar";
+    case PostgresTypeId::kVoid:
+      return "void";
+    case PostgresTypeId::kXid8:
+      return "xid8";
+    case PostgresTypeId::kXid:
+      return "xid";
+    case PostgresTypeId::kXml:
+      return "xml";
+    default:
+      return "";
+  }
+}
+
+static inline std::vector<PostgresTypeId> PostgresTypeIdAll(bool nested) {
+  std::vector<PostgresTypeId> base = {PostgresTypeId::kAclitem,
+                                      PostgresTypeId::kAnyarray,
+                                      PostgresTypeId::kAnycompatiblearray,
+                                      PostgresTypeId::kBit,
+                                      PostgresTypeId::kBool,
+                                      PostgresTypeId::kBox,
+                                      PostgresTypeId::kBpchar,
+                                      PostgresTypeId::kBrinBloomSummary,
+                                      PostgresTypeId::kBrinMinmaxMultiSummary,
+                                      PostgresTypeId::kBytea,
+                                      PostgresTypeId::kCash,
+                                      PostgresTypeId::kChar,
+                                      PostgresTypeId::kCidr,
+                                      PostgresTypeId::kCid,
+                                      PostgresTypeId::kCircle,
+                                      PostgresTypeId::kCstring,
+                                      PostgresTypeId::kDate,
+                                      PostgresTypeId::kFloat4,
+                                      PostgresTypeId::kFloat8,
+                                      PostgresTypeId::kInet,
+                                      PostgresTypeId::kInt2,
+                                      PostgresTypeId::kInt2vector,
+                                      PostgresTypeId::kInt4,
+                                      PostgresTypeId::kInt8,
+                                      PostgresTypeId::kInterval,
+                                      PostgresTypeId::kJson,
+                                      PostgresTypeId::kJsonb,
+                                      PostgresTypeId::kJsonpath,
+                                      PostgresTypeId::kLine,
+                                      PostgresTypeId::kLseg,
+                                      PostgresTypeId::kMacaddr,
+                                      PostgresTypeId::kMacaddr8,
+                                      PostgresTypeId::kMultirange,
+                                      PostgresTypeId::kName,
+                                      PostgresTypeId::kNumeric,
+                                      PostgresTypeId::kOid,
+                                      PostgresTypeId::kOidvector,
+                                      PostgresTypeId::kPath,
+                                      PostgresTypeId::kPgNodeTree,
+                                      PostgresTypeId::kPgNdistinct,
+                                      PostgresTypeId::kPgDependencies,
+                                      PostgresTypeId::kPgLsn,
+                                      PostgresTypeId::kPgMcvList,
+                                      PostgresTypeId::kPgDdlCommand,
+                                      PostgresTypeId::kPgSnapshot,
+                                      PostgresTypeId::kPoint,
+                                      PostgresTypeId::kPoly,
+                                      PostgresTypeId::kRegclass,
+                                      PostgresTypeId::kRegcollation,
+                                      PostgresTypeId::kRegconfig,
+                                      PostgresTypeId::kRegdictionary,
+                                      PostgresTypeId::kRegnamespace,
+                                      PostgresTypeId::kRegoperator,
+                                      PostgresTypeId::kRegoper,
+                                      PostgresTypeId::kRegprocedure,
+                                      PostgresTypeId::kRegproc,
+                                      PostgresTypeId::kRegrole,
+                                      PostgresTypeId::kRegtype,
+                                      PostgresTypeId::kText,
+                                      PostgresTypeId::kTid,
+                                      PostgresTypeId::kTime,
+                                      PostgresTypeId::kTimestamp,
+                                      PostgresTypeId::kTimestamptz,
+                                      PostgresTypeId::kTimetz,
+                                      PostgresTypeId::kTsquery,
+                                      PostgresTypeId::kTsvector,
+                                      PostgresTypeId::kTxidSnapshot,
+                                      PostgresTypeId::kUnknown,
+                                      PostgresTypeId::kUuid,
+                                      PostgresTypeId::kVarbit,
+                                      PostgresTypeId::kVarchar,
+                                      PostgresTypeId::kVoid,
+                                      PostgresTypeId::kXid8,
+                                      PostgresTypeId::kXid,
+                                      PostgresTypeId::kXml};
+
+  if (nested) {
+    base.push_back(PostgresTypeId::kArray);
+    base.push_back(PostgresTypeId::kRecord);
+    base.push_back(PostgresTypeId::kRange);
+    base.push_back(PostgresTypeId::kDomain);
+  }
+
+  return base;
+}
+
+}  // namespace adbcpq

--- a/c/driver/netezza/postgres_type_test.cc
+++ b/c/driver/netezza/postgres_type_test.cc
@@ -1,0 +1,407 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <utility>
+
+#include <gtest/gtest.h>
+#include <nanoarrow/nanoarrow.hpp>
+
+#include "postgres_type.h"
+
+namespace adbcpq {
+
+class MockTypeResolver : public PostgresTypeResolver {
+ public:
+  ArrowErrorCode Init() {
+    auto all_types = PostgresTypeIdAll(false);
+    PostgresTypeResolver::Item item;
+    item.oid = 0;
+
+    // Insert all the base types
+    for (auto type_id : all_types) {
+      std::string typreceive = PostgresTyprecv(type_id);
+      std::string typname = PostgresTypname(type_id);
+      item.oid++;
+      item.typname = typname.c_str();
+      item.typreceive = typreceive.c_str();
+      NANOARROW_RETURN_NOT_OK(Insert(item, nullptr));
+    }
+
+    // Insert one of each nested type
+    item.oid++;
+    item.typname = "_bool";
+    item.typreceive = "array_recv";
+    item.child_oid = GetOID(PostgresTypeId::kBool);
+    NANOARROW_RETURN_NOT_OK(Insert(item, nullptr));
+
+    item.oid++;
+    item.typname = "boolrange";
+    item.typreceive = "range_recv";
+    item.base_oid = GetOID(PostgresTypeId::kBool);
+    NANOARROW_RETURN_NOT_OK(Insert(item, nullptr));
+
+    item.oid++;
+    item.typname = "custombool";
+    item.typreceive = "domain_recv";
+    item.base_oid = GetOID(PostgresTypeId::kBool);
+    NANOARROW_RETURN_NOT_OK(Insert(item, nullptr));
+
+    item.oid++;
+    uint32_t class_oid = item.oid;
+    std::vector<std::pair<std::string, uint32_t>> record_fields = {
+        {"int4_col", GetOID(PostgresTypeId::kInt4)},
+        {"text_col", GetOID(PostgresTypeId::kText)}};
+    InsertClass(class_oid, std::move(record_fields));
+
+    item.oid++;
+    item.typname = "customrecord";
+    item.typreceive = "record_recv";
+    item.class_oid = class_oid;
+
+    NANOARROW_RETURN_NOT_OK(Insert(item, nullptr));
+    return NANOARROW_OK;
+  }
+};
+
+TEST(PostgresTypeTest, PostgresTypeBasic) {
+  PostgresType type(PostgresTypeId::kBool);
+  EXPECT_EQ(type.field_name(), "");
+  EXPECT_EQ(type.typname(), "");
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kBool);
+  EXPECT_EQ(type.oid(), 0);
+  EXPECT_EQ(type.n_children(), 0);
+
+  PostgresType with_info = type.WithPgTypeInfo(1234, "some_typename");
+  EXPECT_EQ(with_info.oid(), 1234);
+  EXPECT_EQ(with_info.typname(), "some_typename");
+  EXPECT_EQ(with_info.type_id(), type.type_id());
+
+  PostgresType with_name = type.WithFieldName("some name");
+  EXPECT_EQ(with_name.field_name(), "some name");
+  EXPECT_EQ(with_name.oid(), type.oid());
+  EXPECT_EQ(with_name.type_id(), type.type_id());
+
+  PostgresType array = type.Array(12345, "array type name");
+  EXPECT_EQ(array.oid(), 12345);
+  EXPECT_EQ(array.typname(), "array type name");
+  EXPECT_EQ(array.n_children(), 1);
+  EXPECT_EQ(array.child(0).oid(), type.oid());
+  EXPECT_EQ(array.child(0).type_id(), type.type_id());
+
+  PostgresType range = type.Range(12345, "range type name");
+  EXPECT_EQ(range.oid(), 12345);
+  EXPECT_EQ(range.typname(), "range type name");
+  EXPECT_EQ(range.n_children(), 1);
+  EXPECT_EQ(range.child(0).oid(), type.oid());
+  EXPECT_EQ(range.child(0).type_id(), type.type_id());
+
+  PostgresType domain = type.Domain(123456, "domain type name");
+  EXPECT_EQ(domain.oid(), 123456);
+  EXPECT_EQ(domain.typname(), "domain type name");
+  EXPECT_EQ(domain.type_id(), type.type_id());
+
+  PostgresType record(PostgresTypeId::kRecord);
+  record.AppendChild("col1", type);
+  EXPECT_EQ(record.type_id(), PostgresTypeId::kRecord);
+  EXPECT_EQ(record.n_children(), 1);
+  EXPECT_EQ(record.child(0).type_id(), type.type_id());
+  EXPECT_EQ(record.child(0).field_name(), "col1");
+}
+
+TEST(PostgresTypeTest, PostgresTypeSetSchema) {
+  nanoarrow::UniqueSchema schema;
+
+  ArrowSchemaInit(schema.get());
+  EXPECT_EQ(PostgresType(PostgresTypeId::kBool).SetSchema(schema.get()), NANOARROW_OK);
+  EXPECT_STREQ(schema->format, "b");
+  schema.reset();
+
+  ArrowSchemaInit(schema.get());
+  EXPECT_EQ(PostgresType(PostgresTypeId::kInt2).SetSchema(schema.get()), NANOARROW_OK);
+  EXPECT_STREQ(schema->format, "s");
+  schema.reset();
+
+  ArrowSchemaInit(schema.get());
+  EXPECT_EQ(PostgresType(PostgresTypeId::kInt4).SetSchema(schema.get()), NANOARROW_OK);
+  EXPECT_STREQ(schema->format, "i");
+  schema.reset();
+
+  ArrowSchemaInit(schema.get());
+  EXPECT_EQ(PostgresType(PostgresTypeId::kInt8).SetSchema(schema.get()), NANOARROW_OK);
+  EXPECT_STREQ(schema->format, "l");
+  schema.reset();
+
+  ArrowSchemaInit(schema.get());
+  EXPECT_EQ(PostgresType(PostgresTypeId::kFloat4).SetSchema(schema.get()), NANOARROW_OK);
+  EXPECT_STREQ(schema->format, "f");
+  schema.reset();
+
+  ArrowSchemaInit(schema.get());
+  EXPECT_EQ(PostgresType(PostgresTypeId::kFloat8).SetSchema(schema.get()), NANOARROW_OK);
+  EXPECT_STREQ(schema->format, "g");
+  schema.reset();
+
+  ArrowSchemaInit(schema.get());
+  EXPECT_EQ(PostgresType(PostgresTypeId::kText).SetSchema(schema.get()), NANOARROW_OK);
+  EXPECT_STREQ(schema->format, "u");
+  schema.reset();
+
+  ArrowSchemaInit(schema.get());
+  EXPECT_EQ(PostgresType(PostgresTypeId::kBytea).SetSchema(schema.get()), NANOARROW_OK);
+  EXPECT_STREQ(schema->format, "z");
+  schema.reset();
+
+  ArrowSchemaInit(schema.get());
+  EXPECT_EQ(PostgresType(PostgresTypeId::kBool).Array().SetSchema(schema.get()),
+            NANOARROW_OK);
+  EXPECT_STREQ(schema->format, "+l");
+  EXPECT_STREQ(schema->children[0]->format, "b");
+  schema.reset();
+
+  ArrowSchemaInit(schema.get());
+  PostgresType record(PostgresTypeId::kRecord);
+  record.AppendChild("col1", PostgresType(PostgresTypeId::kBool));
+  EXPECT_EQ(record.SetSchema(schema.get()), NANOARROW_OK);
+  EXPECT_STREQ(schema->format, "+s");
+  EXPECT_STREQ(schema->children[0]->format, "b");
+  schema.reset();
+
+  ArrowSchemaInit(schema.get());
+  PostgresType unknown(PostgresTypeId::kBrinMinmaxMultiSummary);
+  EXPECT_EQ(unknown.WithPgTypeInfo(0, "some_name").SetSchema(schema.get()), NANOARROW_OK);
+  EXPECT_STREQ(schema->format, "z");
+
+  ArrowStringView value = ArrowCharView("<not found>");
+  ArrowMetadataGetValue(schema->metadata, ArrowCharView("ADBC:postgresql:typname"),
+                        &value);
+  EXPECT_EQ(std::string(value.data, value.size_bytes), "some_name");
+  schema.reset();
+}
+
+TEST(PostgresTypeTest, PostgresTypeFromSchema) {
+  nanoarrow::UniqueSchema schema;
+  PostgresType type;
+  MockTypeResolver resolver;
+  ASSERT_EQ(resolver.Init(), NANOARROW_OK);
+
+  ASSERT_EQ(ArrowSchemaInitFromType(schema.get(), NANOARROW_TYPE_BOOL), NANOARROW_OK);
+  EXPECT_EQ(PostgresType::FromSchema(resolver, schema.get(), &type, nullptr),
+            NANOARROW_OK);
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kBool);
+  schema.reset();
+
+  ASSERT_EQ(ArrowSchemaInitFromType(schema.get(), NANOARROW_TYPE_INT8), NANOARROW_OK);
+  EXPECT_EQ(PostgresType::FromSchema(resolver, schema.get(), &type, nullptr),
+            NANOARROW_OK);
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kInt2);
+  schema.reset();
+
+  ASSERT_EQ(ArrowSchemaInitFromType(schema.get(), NANOARROW_TYPE_UINT8), NANOARROW_OK);
+  EXPECT_EQ(PostgresType::FromSchema(resolver, schema.get(), &type, nullptr),
+            NANOARROW_OK);
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kInt2);
+  schema.reset();
+
+  ASSERT_EQ(ArrowSchemaInitFromType(schema.get(), NANOARROW_TYPE_INT16), NANOARROW_OK);
+  EXPECT_EQ(PostgresType::FromSchema(resolver, schema.get(), &type, nullptr),
+            NANOARROW_OK);
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kInt2);
+  schema.reset();
+
+  ASSERT_EQ(ArrowSchemaInitFromType(schema.get(), NANOARROW_TYPE_UINT16), NANOARROW_OK);
+  EXPECT_EQ(PostgresType::FromSchema(resolver, schema.get(), &type, nullptr),
+            NANOARROW_OK);
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kInt4);
+  schema.reset();
+
+  ASSERT_EQ(ArrowSchemaInitFromType(schema.get(), NANOARROW_TYPE_INT32), NANOARROW_OK);
+  EXPECT_EQ(PostgresType::FromSchema(resolver, schema.get(), &type, nullptr),
+            NANOARROW_OK);
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kInt4);
+  schema.reset();
+
+  ASSERT_EQ(ArrowSchemaInitFromType(schema.get(), NANOARROW_TYPE_UINT32), NANOARROW_OK);
+  EXPECT_EQ(PostgresType::FromSchema(resolver, schema.get(), &type, nullptr),
+            NANOARROW_OK);
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kInt8);
+  schema.reset();
+
+  ASSERT_EQ(ArrowSchemaInitFromType(schema.get(), NANOARROW_TYPE_INT64), NANOARROW_OK);
+  EXPECT_EQ(PostgresType::FromSchema(resolver, schema.get(), &type, nullptr),
+            NANOARROW_OK);
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kInt8);
+  schema.reset();
+
+  ASSERT_EQ(ArrowSchemaInitFromType(schema.get(), NANOARROW_TYPE_FLOAT), NANOARROW_OK);
+  EXPECT_EQ(PostgresType::FromSchema(resolver, schema.get(), &type, nullptr),
+            NANOARROW_OK);
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kFloat4);
+  schema.reset();
+
+  ASSERT_EQ(ArrowSchemaInitFromType(schema.get(), NANOARROW_TYPE_DOUBLE), NANOARROW_OK);
+  EXPECT_EQ(PostgresType::FromSchema(resolver, schema.get(), &type, nullptr),
+            NANOARROW_OK);
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kFloat8);
+  schema.reset();
+
+  ASSERT_EQ(ArrowSchemaInitFromType(schema.get(), NANOARROW_TYPE_BINARY), NANOARROW_OK);
+  EXPECT_EQ(PostgresType::FromSchema(resolver, schema.get(), &type, nullptr),
+            NANOARROW_OK);
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kBytea);
+  schema.reset();
+
+  ASSERT_EQ(ArrowSchemaInitFromType(schema.get(), NANOARROW_TYPE_STRING), NANOARROW_OK);
+  EXPECT_EQ(PostgresType::FromSchema(resolver, schema.get(), &type, nullptr),
+            NANOARROW_OK);
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kText);
+  schema.reset();
+
+  ArrowSchemaInit(schema.get());
+  ASSERT_EQ(ArrowSchemaSetType(schema.get(), NANOARROW_TYPE_LIST), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaSetType(schema->children[0], NANOARROW_TYPE_BOOL), NANOARROW_OK);
+  EXPECT_EQ(PostgresType::FromSchema(resolver, schema.get(), &type, nullptr),
+            NANOARROW_OK);
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kArray);
+  EXPECT_EQ(type.child(0).type_id(), PostgresTypeId::kBool);
+  schema.reset();
+
+  ASSERT_EQ(ArrowSchemaInitFromType(schema.get(), NANOARROW_TYPE_INT64), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaAllocateDictionary(schema.get()), NANOARROW_OK);
+  ASSERT_EQ(ArrowSchemaInitFromType(schema->dictionary, NANOARROW_TYPE_STRING),
+            NANOARROW_OK);
+  EXPECT_EQ(PostgresType::FromSchema(resolver, schema.get(), &type, nullptr),
+            NANOARROW_OK);
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kText);
+  schema.reset();
+
+  ArrowError error;
+  ASSERT_EQ(ArrowSchemaInitFromType(schema.get(), NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO),
+            NANOARROW_OK);
+  EXPECT_EQ(PostgresType::FromSchema(resolver, schema.get(), &type, &error), ENOTSUP);
+  EXPECT_STREQ(error.message,
+               "Can't map Arrow type 'interval_month_day_nano' to Postgres type");
+  schema.reset();
+}
+
+TEST(PostgresTypeTest, PostgresTypeResolver) {
+  PostgresTypeResolver resolver;
+  ArrowError error;
+  PostgresType type;
+  PostgresTypeResolver::Item item;
+
+  // Check error for type not found
+  EXPECT_EQ(resolver.Find(123, &type, &error), EINVAL);
+  EXPECT_STREQ(ArrowErrorMessage(&error), "Postgres type with oid 123 not found");
+
+  // Check error for Array with unknown child
+  item.oid = 123;
+  item.typname = "some_array";
+  item.typreceive = "array_recv";
+  item.child_oid = 1234;
+  EXPECT_EQ(resolver.Insert(item, &error), EINVAL);
+  EXPECT_STREQ(ArrowErrorMessage(&error), "Postgres type with oid 1234 not found");
+
+  // Check error for Range with unknown child
+  item.typname = "some_range";
+  item.typreceive = "range_recv";
+  item.base_oid = 12345;
+  EXPECT_EQ(resolver.Insert(item, &error), EINVAL);
+  EXPECT_STREQ(ArrowErrorMessage(&error), "Postgres type with oid 12345 not found");
+
+  // Check error for Domain with unknown child
+  item.typname = "some_domain";
+  item.typreceive = "domain_recv";
+  item.base_oid = 123456;
+  EXPECT_EQ(resolver.Insert(item, &error), EINVAL);
+  EXPECT_STREQ(ArrowErrorMessage(&error), "Postgres type with oid 123456 not found");
+
+  // Check error for Record with unknown class
+  item.typname = "some_record";
+  item.typreceive = "record_recv";
+  item.class_oid = 123456;
+  EXPECT_EQ(resolver.Insert(item, &error), EINVAL);
+  EXPECT_STREQ(ArrowErrorMessage(&error), "Class definition with oid 123456 not found");
+
+  // Check insert/resolve of regular type
+  item.typname = "some_type_name";
+  item.typreceive = "boolrecv";
+  item.oid = 10;
+  EXPECT_EQ(resolver.Insert(item, &error), NANOARROW_OK);
+  EXPECT_EQ(resolver.Find(10, &type, &error), NANOARROW_OK);
+  EXPECT_EQ(type.oid(), 10);
+  EXPECT_EQ(type.typname(), "some_type_name");
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kBool);
+
+  // Check insert/resolve of array type
+  item.oid = 11;
+  item.typname = "some_array_type_name";
+  item.typreceive = "array_recv";
+  item.child_oid = 10;
+  EXPECT_EQ(resolver.Insert(item, &error), NANOARROW_OK);
+  EXPECT_EQ(resolver.Find(11, &type, &error), NANOARROW_OK);
+  EXPECT_EQ(type.oid(), 11);
+  EXPECT_EQ(type.typname(), "some_array_type_name");
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kArray);
+  EXPECT_EQ(type.child(0).oid(), 10);
+  EXPECT_EQ(type.child(0).type_id(), PostgresTypeId::kBool);
+
+  // Check reverse lookup of array type from item type
+  EXPECT_EQ(resolver.FindArray(10, &type, &error), NANOARROW_OK);
+  EXPECT_EQ(type.oid(), 11);
+
+  // Check insert/resolve of range type
+  item.oid = 12;
+  item.typname = "some_range_type_name";
+  item.typreceive = "range_recv";
+  item.base_oid = 10;
+  EXPECT_EQ(resolver.Insert(item, &error), NANOARROW_OK);
+  EXPECT_EQ(resolver.Find(12, &type, &error), NANOARROW_OK);
+  EXPECT_EQ(type.oid(), 12);
+  EXPECT_EQ(type.typname(), "some_range_type_name");
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kRange);
+  EXPECT_EQ(type.child(0).oid(), 10);
+  EXPECT_EQ(type.child(0).type_id(), PostgresTypeId::kBool);
+
+  // Check insert/resolve of domain type
+  item.oid = 13;
+  item.typname = "some_domain_type_name";
+  item.typreceive = "domain_recv";
+  item.base_oid = 10;
+  EXPECT_EQ(resolver.Insert(item, &error), NANOARROW_OK);
+  EXPECT_EQ(resolver.Find(13, &type, &error), NANOARROW_OK);
+  EXPECT_EQ(type.oid(), 13);
+  EXPECT_EQ(type.typname(), "some_domain_type_name");
+  EXPECT_EQ(type.type_id(), PostgresTypeId::kBool);
+}
+
+TEST(PostgresTypeTest, PostgresTypeResolveRecord) {
+  // Use the mock resolver for the record test since it already has one
+  MockTypeResolver resolver;
+  ASSERT_EQ(resolver.Init(), NANOARROW_OK);
+
+  PostgresType type;
+  EXPECT_EQ(resolver.Find(resolver.GetOID(PostgresTypeId::kRecord), &type, nullptr),
+            NANOARROW_OK);
+  EXPECT_EQ(type.oid(), resolver.GetOID(PostgresTypeId::kRecord));
+  EXPECT_EQ(type.n_children(), 2);
+  EXPECT_EQ(type.child(0).field_name(), "int4_col");
+  EXPECT_EQ(type.child(0).type_id(), PostgresTypeId::kInt4);
+  EXPECT_EQ(type.child(1).field_name(), "text_col");
+  EXPECT_EQ(type.child(1).type_id(), PostgresTypeId::kText);
+}
+
+}  // namespace adbcpq

--- a/c/driver/netezza/postgres_util.h
+++ b/c/driver/netezza/postgres_util.h
@@ -1,0 +1,176 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstring>
+
+#include <nanoarrow/nanoarrow.hpp>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <netinet/in.h>
+#endif
+
+#if defined(__linux__)
+#include <endian.h>
+#elif defined(__APPLE__)
+#include <libkern/OSByteOrder.h>
+#endif
+
+#include "adbc.h"
+
+namespace adbcpq {
+
+#if defined(_WIN32) && defined(_MSC_VER)
+static inline uint16_t SwapNetworkToHost(uint16_t x) { return ntohs(x); }
+static inline uint16_t SwapHostToNetwork(uint16_t x) { return htons(x); }
+static inline uint32_t SwapNetworkToHost(uint32_t x) { return ntohl(x); }
+static inline uint32_t SwapHostToNetwork(uint32_t x) { return htonl(x); }
+static inline uint64_t SwapNetworkToHost(uint64_t x) { return ntohll(x); }
+static inline uint64_t SwapHostToNetwork(uint64_t x) { return htonll(x); }
+#elif defined(_WIN32)
+// e.g., msys2, where ntohll is not necessarily defined
+static inline uint16_t SwapNetworkToHost(uint16_t x) { return ntohs(x); }
+static inline uint16_t SwapHostToNetwork(uint16_t x) { return htons(x); }
+static inline uint32_t SwapNetworkToHost(uint32_t x) { return ntohl(x); }
+static inline uint32_t SwapHostToNetwork(uint32_t x) { return htonl(x); }
+static inline uint64_t SwapNetworkToHost(uint64_t x) {
+  return (((x & 0xFFULL) << 56) | ((x & 0xFF00ULL) << 40) | ((x & 0xFF0000ULL) << 24) |
+          ((x & 0xFF000000ULL) << 8) | ((x & 0xFF00000000ULL) >> 8) |
+          ((x & 0xFF0000000000ULL) >> 24) | ((x & 0xFF000000000000ULL) >> 40) |
+          ((x & 0xFF00000000000000ULL) >> 56));
+}
+static inline uint64_t SwapHostToNetwork(uint64_t x) { return SwapNetworkToHost(x); }
+#elif defined(__APPLE__)
+static inline uint16_t SwapNetworkToHost(uint16_t x) { return OSSwapBigToHostInt16(x); }
+static inline uint16_t SwapHostToNetwork(uint16_t x) { return OSSwapHostToBigInt16(x); }
+static inline uint32_t SwapNetworkToHost(uint32_t x) { return OSSwapBigToHostInt32(x); }
+static inline uint32_t SwapHostToNetwork(uint32_t x) { return OSSwapHostToBigInt32(x); }
+static inline uint64_t SwapNetworkToHost(uint64_t x) { return OSSwapBigToHostInt64(x); }
+static inline uint64_t SwapHostToNetwork(uint64_t x) { return OSSwapHostToBigInt64(x); }
+#else
+static inline uint16_t SwapNetworkToHost(uint16_t x) { return be16toh(x); }
+static inline uint16_t SwapHostToNetwork(uint16_t x) { return htobe16(x); }
+static inline uint32_t SwapNetworkToHost(uint32_t x) { return be32toh(x); }
+static inline uint32_t SwapHostToNetwork(uint32_t x) { return htobe32(x); }
+static inline uint64_t SwapNetworkToHost(uint64_t x) { return be64toh(x); }
+static inline uint64_t SwapHostToNetwork(uint64_t x) { return htobe64(x); }
+#endif
+
+/// Endianness helpers
+
+static inline uint16_t LoadNetworkUInt16(const char* buf) {
+  uint16_t v = 0;
+  std::memcpy(&v, buf, sizeof(uint16_t));
+  return ntohs(v);
+}
+
+static inline uint32_t LoadNetworkUInt32(const char* buf) {
+  uint32_t v = 0;
+  std::memcpy(&v, buf, sizeof(uint32_t));
+  return ntohl(v);
+}
+
+static inline int64_t LoadNetworkUInt64(const char* buf) {
+  uint64_t v = 0;
+  std::memcpy(&v, buf, sizeof(uint64_t));
+  return SwapNetworkToHost(v);
+}
+
+static inline int16_t LoadNetworkInt16(const char* buf) {
+  return static_cast<int16_t>(LoadNetworkUInt16(buf));
+}
+
+static inline int32_t LoadNetworkInt32(const char* buf) {
+  return static_cast<int32_t>(LoadNetworkUInt32(buf));
+}
+
+static inline int64_t LoadNetworkInt64(const char* buf) {
+  return static_cast<int64_t>(LoadNetworkUInt64(buf));
+}
+
+static inline double LoadNetworkFloat8(const char* buf) {
+  uint64_t vint;
+  memcpy(&vint, buf, sizeof(uint64_t));
+  vint = SwapHostToNetwork(vint);
+  double out;
+  memcpy(&out, &vint, sizeof(double));
+  return out;
+}
+
+#define ADBC_REGISTER_TO_NETWORK_FUNC(size)                          \
+  static inline uint##size##_t ToNetworkInt##size(int##size##_t v) { \
+    return SwapHostToNetwork(static_cast<uint##size##_t>(v));        \
+  }
+
+ADBC_REGISTER_TO_NETWORK_FUNC(16)
+ADBC_REGISTER_TO_NETWORK_FUNC(32)
+ADBC_REGISTER_TO_NETWORK_FUNC(64)
+
+static inline uint32_t ToNetworkFloat4(float v) {
+  uint32_t vint;
+  memcpy(&vint, &v, sizeof(uint32_t));
+  return SwapHostToNetwork(vint);
+}
+
+static inline uint64_t ToNetworkFloat8(double v) {
+  uint64_t vint;
+  memcpy(&vint, &v, sizeof(uint64_t));
+  return SwapHostToNetwork(vint);
+}
+
+/// Helper to manage resources with RAII
+
+template <typename T>
+struct Releaser {
+  static void Release(T* value) {
+    if (value->release) {
+      value->release(value);
+    }
+  }
+};
+
+template <>
+struct Releaser<struct ArrowBuffer> {
+  static void Release(struct ArrowBuffer* buffer) { ArrowBufferReset(buffer); }
+};
+
+template <>
+struct Releaser<struct ArrowArrayView> {
+  static void Release(struct ArrowArrayView* value) {
+    if (value->storage_type != NANOARROW_TYPE_UNINITIALIZED) {
+      ArrowArrayViewReset(value);
+    }
+  }
+};
+
+template <typename Resource>
+struct Handle {
+  Resource value;
+
+  Handle() { std::memset(&value, 0, sizeof(value)); }
+
+  ~Handle() { reset(); }
+
+  Resource* operator->() { return &value; }
+
+  void reset() { Releaser<Resource>::Release(&value);  }
+};
+
+}  // namespace adbcpq

--- a/c/driver/netezza/postgresql.cc
+++ b/c/driver/netezza/postgresql.cc
@@ -1,0 +1,934 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// A libpq-based PostgreSQL driver for ADBC.
+
+#include <cstring>
+#include <memory>
+
+#include <adbc.h>
+
+#include "common/utils.h"
+#include "connection.h"
+#include "database.h"
+#include "statement.h"
+
+using adbcpq::PostgresConnection;
+using adbcpq::PostgresDatabase;
+using adbcpq::PostgresStatement;
+
+// ---------------------------------------------------------------------
+// ADBC interface implementation - as private functions so that these
+// don't get replaced by the dynamic linker. If we implemented these
+// under the Adbc* names, then in DriverInit, the linker may resolve
+// functions to the address of the functions provided by the driver
+// manager instead of our functions.
+//
+// We could also:
+// - Play games with RTLD_DEEPBIND - but this doesn't work with ASan
+// - Use __attribute__((visibility("protected"))) - but this is
+//   apparently poorly supported by some linkers
+// - Play with -Bsymbolic(-functions) - but this has other
+//   consequences and complicates the build setup
+//
+// So in the end some manual effort here was chosen.
+
+// ---------------------------------------------------------------------
+// AdbcError
+
+namespace {
+const struct AdbcError* PostgresErrorFromArrayStream(struct ArrowArrayStream* stream,
+                                                     AdbcStatusCode* status) {
+  // Currently only valid for TupleReader
+  return adbcpq::TupleReader::ErrorFromArrayStream(stream, status);
+}
+}  // namespace
+
+int AdbcErrorGetDetailCount(const struct AdbcError* error) {
+  return CommonErrorGetDetailCount(error);
+}
+
+struct AdbcErrorDetail AdbcErrorGetDetail(const struct AdbcError* error, int index) {
+  return CommonErrorGetDetail(error, index);
+}
+
+const struct AdbcError* AdbcErrorFromArrayStream(struct ArrowArrayStream* stream,
+                                                 AdbcStatusCode* status) {
+  return PostgresErrorFromArrayStream(stream, status);
+}
+
+// ---------------------------------------------------------------------
+// AdbcDatabase
+
+namespace {
+AdbcStatusCode PostgresDatabaseInit(struct AdbcDatabase* database,
+                                    struct AdbcError* error) {
+  if (!database || !database->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr = reinterpret_cast<std::shared_ptr<PostgresDatabase>*>(database->private_data);
+  return (*ptr)->Init(error);
+}
+
+AdbcStatusCode PostgresDatabaseNew(struct AdbcDatabase* database,
+                                   struct AdbcError* error) {
+  if (!database) {
+    SetError(error, "%s", "[libpq] database must not be null");
+    return ADBC_STATUS_INVALID_STATE;
+  }
+  if (database->private_data) {
+    SetError(error, "%s", "[libpq] database is already initialized");
+    return ADBC_STATUS_INVALID_STATE;
+  }
+  auto impl = std::make_shared<PostgresDatabase>();
+  database->private_data = new std::shared_ptr<PostgresDatabase>(impl);
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresDatabaseRelease(struct AdbcDatabase* database,
+                                       struct AdbcError* error) {
+  if (!database->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr = reinterpret_cast<std::shared_ptr<PostgresDatabase>*>(database->private_data);
+  AdbcStatusCode status = (*ptr)->Release(error);
+  delete ptr;
+  database->private_data = nullptr;
+  return status;
+}
+
+AdbcStatusCode PostgresDatabaseGetOption(struct AdbcDatabase* database, const char* key,
+                                         char* value, size_t* length,
+                                         struct AdbcError* error) {
+  if (!database->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr = reinterpret_cast<std::shared_ptr<PostgresDatabase>*>(database->private_data);
+  return (*ptr)->GetOption(key, value, length, error);
+}
+
+AdbcStatusCode PostgresDatabaseGetOptionBytes(struct AdbcDatabase* database,
+                                              const char* key, uint8_t* value,
+                                              size_t* length, struct AdbcError* error) {
+  if (!database->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr = reinterpret_cast<std::shared_ptr<PostgresDatabase>*>(database->private_data);
+  return (*ptr)->GetOptionBytes(key, value, length, error);
+}
+
+AdbcStatusCode PostgresDatabaseGetOptionDouble(struct AdbcDatabase* database,
+                                               const char* key, double* value,
+                                               struct AdbcError* error) {
+  if (!database->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr = reinterpret_cast<std::shared_ptr<PostgresDatabase>*>(database->private_data);
+  return (*ptr)->GetOptionDouble(key, value, error);
+}
+
+AdbcStatusCode PostgresDatabaseGetOptionInt(struct AdbcDatabase* database,
+                                            const char* key, int64_t* value,
+                                            struct AdbcError* error) {
+  if (!database->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr = reinterpret_cast<std::shared_ptr<PostgresDatabase>*>(database->private_data);
+  return (*ptr)->GetOptionInt(key, value, error);
+}
+
+AdbcStatusCode PostgresDatabaseSetOption(struct AdbcDatabase* database, const char* key,
+                                         const char* value, struct AdbcError* error) {
+  if (!database || !database->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr = reinterpret_cast<std::shared_ptr<PostgresDatabase>*>(database->private_data);
+  return (*ptr)->SetOption(key, value, error);
+}
+
+AdbcStatusCode PostgresDatabaseSetOptionBytes(struct AdbcDatabase* database,
+                                              const char* key, const uint8_t* value,
+                                              size_t length, struct AdbcError* error) {
+  if (!database->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr = reinterpret_cast<std::shared_ptr<PostgresDatabase>*>(database->private_data);
+  return (*ptr)->SetOptionBytes(key, value, length, error);
+}
+
+AdbcStatusCode PostgresDatabaseSetOptionDouble(struct AdbcDatabase* database,
+                                               const char* key, double value,
+                                               struct AdbcError* error) {
+  if (!database->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr = reinterpret_cast<std::shared_ptr<PostgresDatabase>*>(database->private_data);
+  return (*ptr)->SetOptionDouble(key, value, error);
+}
+
+AdbcStatusCode PostgresDatabaseSetOptionInt(struct AdbcDatabase* database,
+                                            const char* key, int64_t value,
+                                            struct AdbcError* error) {
+  if (!database->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr = reinterpret_cast<std::shared_ptr<PostgresDatabase>*>(database->private_data);
+  return (*ptr)->SetOptionInt(key, value, error);
+}
+}  // namespace
+
+AdbcStatusCode AdbcDatabaseGetOption(struct AdbcDatabase* database, const char* key,
+                                     char* value, size_t* length,
+                                     struct AdbcError* error) {
+  return PostgresDatabaseGetOption(database, key, value, length, error);
+}
+
+AdbcStatusCode AdbcDatabaseGetOptionBytes(struct AdbcDatabase* database, const char* key,
+                                          uint8_t* value, size_t* length,
+                                          struct AdbcError* error) {
+  return PostgresDatabaseGetOptionBytes(database, key, value, length, error);
+}
+
+AdbcStatusCode AdbcDatabaseGetOptionInt(struct AdbcDatabase* database, const char* key,
+                                        int64_t* value, struct AdbcError* error) {
+  return PostgresDatabaseGetOptionInt(database, key, value, error);
+}
+
+AdbcStatusCode AdbcDatabaseGetOptionDouble(struct AdbcDatabase* database, const char* key,
+                                           double* value, struct AdbcError* error) {
+  return PostgresDatabaseGetOptionDouble(database, key, value, error);
+}
+
+AdbcStatusCode AdbcDatabaseInit(struct AdbcDatabase* database, struct AdbcError* error) {
+  return PostgresDatabaseInit(database, error);
+}
+
+AdbcStatusCode AdbcDatabaseNew(struct AdbcDatabase* database, struct AdbcError* error) {
+  return PostgresDatabaseNew(database, error);
+}
+
+AdbcStatusCode AdbcDatabaseRelease(struct AdbcDatabase* database,
+                                   struct AdbcError* error) {
+  return PostgresDatabaseRelease(database, error);
+}
+
+AdbcStatusCode AdbcDatabaseSetOption(struct AdbcDatabase* database, const char* key,
+                                     const char* value, struct AdbcError* error) {
+  return PostgresDatabaseSetOption(database, key, value, error);
+}
+
+AdbcStatusCode AdbcDatabaseSetOptionBytes(struct AdbcDatabase* database, const char* key,
+                                          const uint8_t* value, size_t length,
+                                          struct AdbcError* error) {
+  return PostgresDatabaseSetOptionBytes(database, key, value, length, error);
+}
+
+AdbcStatusCode AdbcDatabaseSetOptionInt(struct AdbcDatabase* database, const char* key,
+                                        int64_t value, struct AdbcError* error) {
+  return PostgresDatabaseSetOptionInt(database, key, value, error);
+}
+
+AdbcStatusCode AdbcDatabaseSetOptionDouble(struct AdbcDatabase* database, const char* key,
+                                           double value, struct AdbcError* error) {
+  return PostgresDatabaseSetOptionDouble(database, key, value, error);
+}
+
+// ---------------------------------------------------------------------
+// AdbcConnection
+
+namespace {
+AdbcStatusCode PostgresConnectionCancel(struct AdbcConnection* connection,
+                                        struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  return (*ptr)->Cancel(error);
+}
+
+AdbcStatusCode PostgresConnectionCommit(struct AdbcConnection* connection,
+                                        struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  return (*ptr)->Commit(error);
+}
+
+AdbcStatusCode PostgresConnectionGetInfo(struct AdbcConnection* connection,
+                                         const uint32_t* info_codes,
+                                         size_t info_codes_length,
+                                         struct ArrowArrayStream* stream,
+                                         struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  return (*ptr)->GetInfo(connection, info_codes, info_codes_length, stream, error);
+}
+
+AdbcStatusCode PostgresConnectionGetObjects(
+    struct AdbcConnection* connection, int depth, const char* catalog,
+    const char* db_schema, const char* table_name, const char** table_types,
+    const char* column_name, struct ArrowArrayStream* stream, struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  return (*ptr)->GetObjects(connection, depth, catalog, db_schema, table_name,
+                            table_types, column_name, stream, error);
+}
+
+AdbcStatusCode PostgresConnectionGetOption(struct AdbcConnection* connection,
+                                           const char* key, char* value, size_t* length,
+                                           struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  return (*ptr)->GetOption(key, value, length, error);
+}
+
+AdbcStatusCode PostgresConnectionGetOptionBytes(struct AdbcConnection* connection,
+                                                const char* key, uint8_t* value,
+                                                size_t* length, struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  return (*ptr)->GetOptionBytes(key, value, length, error);
+}
+
+AdbcStatusCode PostgresConnectionGetOptionDouble(struct AdbcConnection* connection,
+                                                 const char* key, double* value,
+                                                 struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  return (*ptr)->GetOptionDouble(key, value, error);
+}
+
+AdbcStatusCode PostgresConnectionGetOptionInt(struct AdbcConnection* connection,
+                                              const char* key, int64_t* value,
+                                              struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  return (*ptr)->GetOptionInt(key, value, error);
+}
+
+AdbcStatusCode PostgresConnectionGetStatistics(struct AdbcConnection* connection,
+                                               const char* catalog, const char* db_schema,
+                                               const char* table_name, char approximate,
+                                               struct ArrowArrayStream* out,
+                                               struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  return (*ptr)->GetStatistics(catalog, db_schema, table_name, approximate == 1, out,
+                               error);
+}
+
+AdbcStatusCode PostgresConnectionGetStatisticNames(struct AdbcConnection* connection,
+                                                   struct ArrowArrayStream* out,
+                                                   struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  return (*ptr)->GetStatisticNames(out, error);
+}
+
+AdbcStatusCode PostgresConnectionGetTableSchema(
+    struct AdbcConnection* connection, const char* catalog, const char* db_schema,
+    const char* table_name, struct ArrowSchema* schema, struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  return (*ptr)->GetTableSchema(catalog, db_schema, table_name, schema, error);
+}
+
+AdbcStatusCode PostgresConnectionGetTableTypes(struct AdbcConnection* connection,
+                                               struct ArrowArrayStream* stream,
+                                               struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  return (*ptr)->GetTableTypes(connection, stream, error);
+}
+
+AdbcStatusCode PostgresConnectionInit(struct AdbcConnection* connection,
+                                      struct AdbcDatabase* database,
+                                      struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  return (*ptr)->Init(database, error);
+}
+
+AdbcStatusCode PostgresConnectionNew(struct AdbcConnection* connection,
+                                     struct AdbcError* error) {
+  auto impl = std::make_shared<PostgresConnection>();
+  connection->private_data = new std::shared_ptr<PostgresConnection>(impl);
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresConnectionReadPartition(struct AdbcConnection* connection,
+                                               const uint8_t* serialized_partition,
+                                               size_t serialized_length,
+                                               struct ArrowArrayStream* out,
+                                               struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  return ADBC_STATUS_NOT_IMPLEMENTED;
+}
+
+AdbcStatusCode PostgresConnectionRelease(struct AdbcConnection* connection,
+                                         struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  AdbcStatusCode status = (*ptr)->Release(error);
+  delete ptr;
+  connection->private_data = nullptr;
+  return status;
+}
+
+AdbcStatusCode PostgresConnectionRollback(struct AdbcConnection* connection,
+                                          struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  return (*ptr)->Rollback(error);
+}
+
+AdbcStatusCode PostgresConnectionSetOption(struct AdbcConnection* connection,
+                                           const char* key, const char* value,
+                                           struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  return (*ptr)->SetOption(key, value, error);
+}
+
+AdbcStatusCode PostgresConnectionSetOptionBytes(struct AdbcConnection* connection,
+                                                const char* key, const uint8_t* value,
+                                                size_t length, struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  return (*ptr)->SetOptionBytes(key, value, length, error);
+}
+
+AdbcStatusCode PostgresConnectionSetOptionDouble(struct AdbcConnection* connection,
+                                                 const char* key, double value,
+                                                 struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  return (*ptr)->SetOptionDouble(key, value, error);
+}
+
+AdbcStatusCode PostgresConnectionSetOptionInt(struct AdbcConnection* connection,
+                                              const char* key, int64_t value,
+                                              struct AdbcError* error) {
+  if (!connection->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  return (*ptr)->SetOptionInt(key, value, error);
+}
+
+}  // namespace
+
+AdbcStatusCode AdbcConnectionCancel(struct AdbcConnection* connection,
+                                    struct AdbcError* error) {
+  return PostgresConnectionCancel(connection, error);
+}
+
+AdbcStatusCode AdbcConnectionCommit(struct AdbcConnection* connection,
+                                    struct AdbcError* error) {
+  return PostgresConnectionCommit(connection, error);
+}
+
+AdbcStatusCode AdbcConnectionGetInfo(struct AdbcConnection* connection,
+                                     const uint32_t* info_codes, size_t info_codes_length,
+                                     struct ArrowArrayStream* stream,
+                                     struct AdbcError* error) {
+  return PostgresConnectionGetInfo(connection, info_codes, info_codes_length, stream,
+                                   error);
+}
+
+AdbcStatusCode AdbcConnectionGetObjects(struct AdbcConnection* connection, int depth,
+                                        const char* catalog, const char* db_schema,
+                                        const char* table_name, const char** table_types,
+                                        const char* column_name,
+                                        struct ArrowArrayStream* stream,
+                                        struct AdbcError* error) {
+  return PostgresConnectionGetObjects(connection, depth, catalog, db_schema, table_name,
+                                      table_types, column_name, stream, error);
+}
+
+AdbcStatusCode AdbcConnectionGetOption(struct AdbcConnection* connection, const char* key,
+                                       char* value, size_t* length,
+                                       struct AdbcError* error) {
+  return PostgresConnectionGetOption(connection, key, value, length, error);
+}
+
+AdbcStatusCode AdbcConnectionGetOptionBytes(struct AdbcConnection* connection,
+                                            const char* key, uint8_t* value,
+                                            size_t* length, struct AdbcError* error) {
+  return PostgresConnectionGetOptionBytes(connection, key, value, length, error);
+}
+
+AdbcStatusCode AdbcConnectionGetOptionInt(struct AdbcConnection* connection,
+                                          const char* key, int64_t* value,
+                                          struct AdbcError* error) {
+  return PostgresConnectionGetOptionInt(connection, key, value, error);
+}
+
+AdbcStatusCode AdbcConnectionGetOptionDouble(struct AdbcConnection* connection,
+                                             const char* key, double* value,
+                                             struct AdbcError* error) {
+  return PostgresConnectionGetOptionDouble(connection, key, value, error);
+}
+
+AdbcStatusCode AdbcConnectionGetStatistics(struct AdbcConnection* connection,
+                                           const char* catalog, const char* db_schema,
+                                           const char* table_name, char approximate,
+                                           struct ArrowArrayStream* out,
+                                           struct AdbcError* error) {
+  return PostgresConnectionGetStatistics(connection, catalog, db_schema, table_name,
+                                         approximate, out, error);
+}
+
+AdbcStatusCode AdbcConnectionGetStatisticNames(struct AdbcConnection* connection,
+                                               struct ArrowArrayStream* out,
+                                               struct AdbcError* error) {
+  return PostgresConnectionGetStatisticNames(connection, out, error);
+}
+
+AdbcStatusCode AdbcConnectionGetTableSchema(struct AdbcConnection* connection,
+                                            const char* catalog, const char* db_schema,
+                                            const char* table_name,
+                                            struct ArrowSchema* schema,
+                                            struct AdbcError* error) {
+  return PostgresConnectionGetTableSchema(connection, catalog, db_schema, table_name,
+                                          schema, error);
+}
+
+AdbcStatusCode AdbcConnectionGetTableTypes(struct AdbcConnection* connection,
+                                           struct ArrowArrayStream* stream,
+                                           struct AdbcError* error) {
+  return PostgresConnectionGetTableTypes(connection, stream, error);
+}
+
+AdbcStatusCode AdbcConnectionInit(struct AdbcConnection* connection,
+                                  struct AdbcDatabase* database,
+                                  struct AdbcError* error) {
+  return PostgresConnectionInit(connection, database, error);
+}
+
+AdbcStatusCode AdbcConnectionNew(struct AdbcConnection* connection,
+                                 struct AdbcError* error) {
+  return PostgresConnectionNew(connection, error);
+}
+
+AdbcStatusCode AdbcConnectionReadPartition(struct AdbcConnection* connection,
+                                           const uint8_t* serialized_partition,
+                                           size_t serialized_length,
+                                           struct ArrowArrayStream* out,
+                                           struct AdbcError* error) {
+  return PostgresConnectionReadPartition(connection, serialized_partition,
+                                         serialized_length, out, error);
+}
+
+AdbcStatusCode AdbcConnectionRelease(struct AdbcConnection* connection,
+                                     struct AdbcError* error) {
+  return PostgresConnectionRelease(connection, error);
+}
+
+AdbcStatusCode AdbcConnectionRollback(struct AdbcConnection* connection,
+                                      struct AdbcError* error) {
+  return PostgresConnectionRollback(connection, error);
+}
+
+AdbcStatusCode AdbcConnectionSetOption(struct AdbcConnection* connection, const char* key,
+                                       const char* value, struct AdbcError* error) {
+  return PostgresConnectionSetOption(connection, key, value, error);
+}
+
+AdbcStatusCode AdbcConnectionSetOptionBytes(struct AdbcConnection* connection,
+                                            const char* key, const uint8_t* value,
+                                            size_t length, struct AdbcError* error) {
+  return PostgresConnectionSetOptionBytes(connection, key, value, length, error);
+}
+
+AdbcStatusCode AdbcConnectionSetOptionInt(struct AdbcConnection* connection,
+                                          const char* key, int64_t value,
+                                          struct AdbcError* error) {
+  return PostgresConnectionSetOptionInt(connection, key, value, error);
+}
+
+AdbcStatusCode AdbcConnectionSetOptionDouble(struct AdbcConnection* connection,
+                                             const char* key, double value,
+                                             struct AdbcError* error) {
+  return PostgresConnectionSetOptionDouble(connection, key, value, error);
+}
+
+// ---------------------------------------------------------------------
+// AdbcStatement
+
+namespace {
+AdbcStatusCode PostgresStatementBind(struct AdbcStatement* statement,
+                                     struct ArrowArray* values,
+                                     struct ArrowSchema* schema,
+                                     struct AdbcError* error) {
+  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto* ptr =
+      reinterpret_cast<std::shared_ptr<PostgresStatement>*>(statement->private_data);
+  return (*ptr)->Bind(values, schema, error);
+}
+
+AdbcStatusCode PostgresStatementBindStream(struct AdbcStatement* statement,
+                                           struct ArrowArrayStream* stream,
+                                           struct AdbcError* error) {
+  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto* ptr =
+      reinterpret_cast<std::shared_ptr<PostgresStatement>*>(statement->private_data);
+  return (*ptr)->Bind(stream, error);
+}
+
+AdbcStatusCode PostgresStatementCancel(struct AdbcStatement* statement,
+                                       struct AdbcError* error) {
+  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto* ptr =
+      reinterpret_cast<std::shared_ptr<PostgresStatement>*>(statement->private_data);
+  return (*ptr)->Cancel(error);
+}
+
+AdbcStatusCode PostgresStatementExecutePartitions(struct AdbcStatement* statement,
+                                                  struct ArrowSchema* schema,
+                                                  struct AdbcPartitions* partitions,
+                                                  int64_t* rows_affected,
+                                                  struct AdbcError* error) {
+  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
+  return ADBC_STATUS_NOT_IMPLEMENTED;
+}
+
+AdbcStatusCode PostgresStatementExecuteQuery(struct AdbcStatement* statement,
+                                             struct ArrowArrayStream* output,
+                                             int64_t* rows_affected,
+                                             struct AdbcError* error) {
+  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto* ptr =
+      reinterpret_cast<std::shared_ptr<PostgresStatement>*>(statement->private_data);
+  return (*ptr)->ExecuteQuery(output, rows_affected, error);
+}
+
+AdbcStatusCode PostgresStatementExecuteSchema(struct AdbcStatement* statement,
+                                              struct ArrowSchema* schema,
+                                              struct AdbcError* error) {
+  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto* ptr =
+      reinterpret_cast<std::shared_ptr<PostgresStatement>*>(statement->private_data);
+  return (*ptr)->ExecuteSchema(schema, error);
+}
+
+AdbcStatusCode PostgresStatementGetOption(struct AdbcStatement* statement,
+                                          const char* key, char* value, size_t* length,
+                                          struct AdbcError* error) {
+  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresStatement>*>(statement->private_data);
+  return (*ptr)->GetOption(key, value, length, error);
+}
+
+AdbcStatusCode PostgresStatementGetOptionBytes(struct AdbcStatement* statement,
+                                               const char* key, uint8_t* value,
+                                               size_t* length, struct AdbcError* error) {
+  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresStatement>*>(statement->private_data);
+  return (*ptr)->GetOptionBytes(key, value, length, error);
+}
+
+AdbcStatusCode PostgresStatementGetOptionDouble(struct AdbcStatement* statement,
+                                                const char* key, double* value,
+                                                struct AdbcError* error) {
+  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresStatement>*>(statement->private_data);
+  return (*ptr)->GetOptionDouble(key, value, error);
+}
+
+AdbcStatusCode PostgresStatementGetOptionInt(struct AdbcStatement* statement,
+                                             const char* key, int64_t* value,
+                                             struct AdbcError* error) {
+  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresStatement>*>(statement->private_data);
+  return (*ptr)->GetOptionInt(key, value, error);
+}
+
+AdbcStatusCode PostgresStatementGetParameterSchema(struct AdbcStatement* statement,
+                                                   struct ArrowSchema* schema,
+                                                   struct AdbcError* error) {
+  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto* ptr =
+      reinterpret_cast<std::shared_ptr<PostgresStatement>*>(statement->private_data);
+  return (*ptr)->GetParameterSchema(schema, error);
+}
+
+AdbcStatusCode PostgresStatementNew(struct AdbcConnection* connection,
+                                    struct AdbcStatement* statement,
+                                    struct AdbcError* error) {
+  auto impl = std::make_shared<PostgresStatement>();
+  statement->private_data = new std::shared_ptr<PostgresStatement>(impl);
+  return impl->New(connection, error);
+}
+
+AdbcStatusCode PostgresStatementPrepare(struct AdbcStatement* statement,
+                                        struct AdbcError* error) {
+  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto* ptr =
+      reinterpret_cast<std::shared_ptr<PostgresStatement>*>(statement->private_data);
+  return (*ptr)->Prepare(error);
+}
+
+AdbcStatusCode PostgresStatementRelease(struct AdbcStatement* statement,
+                                        struct AdbcError* error) {
+  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto* ptr =
+      reinterpret_cast<std::shared_ptr<PostgresStatement>*>(statement->private_data);
+  auto status = (*ptr)->Release(error);
+  delete ptr;
+  statement->private_data = nullptr;
+  return status;
+}
+
+AdbcStatusCode PostgresStatementSetOption(struct AdbcStatement* statement,
+                                          const char* key, const char* value,
+                                          struct AdbcError* error) {
+  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto* ptr =
+      reinterpret_cast<std::shared_ptr<PostgresStatement>*>(statement->private_data);
+  return (*ptr)->SetOption(key, value, error);
+}
+
+AdbcStatusCode PostgresStatementSetOptionBytes(struct AdbcStatement* statement,
+                                               const char* key, const uint8_t* value,
+                                               size_t length, struct AdbcError* error) {
+  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresStatement>*>(statement->private_data);
+  return (*ptr)->SetOptionBytes(key, value, length, error);
+}
+
+AdbcStatusCode PostgresStatementSetOptionDouble(struct AdbcStatement* statement,
+                                                const char* key, double value,
+                                                struct AdbcError* error) {
+  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresStatement>*>(statement->private_data);
+  return (*ptr)->SetOptionDouble(key, value, error);
+}
+
+AdbcStatusCode PostgresStatementSetOptionInt(struct AdbcStatement* statement,
+                                             const char* key, int64_t value,
+                                             struct AdbcError* error) {
+  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto ptr =
+      reinterpret_cast<std::shared_ptr<PostgresStatement>*>(statement->private_data);
+  return (*ptr)->SetOptionInt(key, value, error);
+}
+
+AdbcStatusCode PostgresStatementSetSqlQuery(struct AdbcStatement* statement,
+                                            const char* query, struct AdbcError* error) {
+  if (!statement->private_data) return ADBC_STATUS_INVALID_STATE;
+  auto* ptr =
+      reinterpret_cast<std::shared_ptr<PostgresStatement>*>(statement->private_data);
+  return (*ptr)->SetSqlQuery(query, error);
+}
+}  // namespace
+
+AdbcStatusCode AdbcStatementBind(struct AdbcStatement* statement,
+                                 struct ArrowArray* values, struct ArrowSchema* schema,
+                                 struct AdbcError* error) {
+  return PostgresStatementBind(statement, values, schema, error);
+}
+
+AdbcStatusCode AdbcStatementBindStream(struct AdbcStatement* statement,
+                                       struct ArrowArrayStream* stream,
+                                       struct AdbcError* error) {
+  return PostgresStatementBindStream(statement, stream, error);
+}
+
+AdbcStatusCode AdbcStatementCancel(struct AdbcStatement* statement,
+                                   struct AdbcError* error) {
+  return PostgresStatementCancel(statement, error);
+}
+
+AdbcStatusCode AdbcStatementExecutePartitions(struct AdbcStatement* statement,
+                                              ArrowSchema* schema,
+                                              struct AdbcPartitions* partitions,
+                                              int64_t* rows_affected,
+                                              struct AdbcError* error) {
+  return PostgresStatementExecutePartitions(statement, schema, partitions, rows_affected,
+                                            error);
+}
+
+AdbcStatusCode AdbcStatementExecuteQuery(struct AdbcStatement* statement,
+                                         struct ArrowArrayStream* output,
+                                         int64_t* rows_affected,
+                                         struct AdbcError* error) {
+  return PostgresStatementExecuteQuery(statement, output, rows_affected, error);
+}
+
+AdbcStatusCode AdbcStatementExecuteSchema(struct AdbcStatement* statement,
+                                          ArrowSchema* schema, struct AdbcError* error) {
+  return PostgresStatementExecuteSchema(statement, schema, error);
+}
+
+AdbcStatusCode AdbcStatementGetOption(struct AdbcStatement* statement, const char* key,
+                                      char* value, size_t* length,
+                                      struct AdbcError* error) {
+  return PostgresStatementGetOption(statement, key, value, length, error);
+}
+
+AdbcStatusCode AdbcStatementGetOptionBytes(struct AdbcStatement* statement,
+                                           const char* key, uint8_t* value,
+                                           size_t* length, struct AdbcError* error) {
+  return PostgresStatementGetOptionBytes(statement, key, value, length, error);
+}
+
+AdbcStatusCode AdbcStatementGetOptionInt(struct AdbcStatement* statement, const char* key,
+                                         int64_t* value, struct AdbcError* error) {
+  return PostgresStatementGetOptionInt(statement, key, value, error);
+}
+
+AdbcStatusCode AdbcStatementGetOptionDouble(struct AdbcStatement* statement,
+                                            const char* key, double* value,
+                                            struct AdbcError* error) {
+  return PostgresStatementGetOptionDouble(statement, key, value, error);
+}
+
+AdbcStatusCode AdbcStatementGetParameterSchema(struct AdbcStatement* statement,
+                                               struct ArrowSchema* schema,
+                                               struct AdbcError* error) {
+  return PostgresStatementGetParameterSchema(statement, schema, error);
+}
+
+AdbcStatusCode AdbcStatementNew(struct AdbcConnection* connection,
+                                struct AdbcStatement* statement,
+                                struct AdbcError* error) {
+  return PostgresStatementNew(connection, statement, error);
+}
+
+AdbcStatusCode AdbcStatementPrepare(struct AdbcStatement* statement,
+                                    struct AdbcError* error) {
+  return PostgresStatementPrepare(statement, error);
+}
+
+AdbcStatusCode AdbcStatementRelease(struct AdbcStatement* statement,
+                                    struct AdbcError* error) {
+  return PostgresStatementRelease(statement, error);
+}
+
+AdbcStatusCode AdbcStatementSetOption(struct AdbcStatement* statement, const char* key,
+                                      const char* value, struct AdbcError* error) {
+  return PostgresStatementSetOption(statement, key, value, error);
+}
+
+AdbcStatusCode AdbcStatementSetOptionBytes(struct AdbcStatement* statement,
+                                           const char* key, const uint8_t* value,
+                                           size_t length, struct AdbcError* error) {
+  return PostgresStatementSetOptionBytes(statement, key, value, length, error);
+}
+
+AdbcStatusCode AdbcStatementSetOptionInt(struct AdbcStatement* statement, const char* key,
+                                         int64_t value, struct AdbcError* error) {
+  return PostgresStatementSetOptionInt(statement, key, value, error);
+}
+
+AdbcStatusCode AdbcStatementSetOptionDouble(struct AdbcStatement* statement,
+                                            const char* key, double value,
+                                            struct AdbcError* error) {
+  return PostgresStatementSetOptionDouble(statement, key, value, error);
+}
+
+AdbcStatusCode AdbcStatementSetSqlQuery(struct AdbcStatement* statement,
+                                        const char* query, struct AdbcError* error) {
+  return PostgresStatementSetSqlQuery(statement, query, error);
+}
+
+extern "C" {
+ADBC_EXPORT
+AdbcStatusCode PostgresqlDriverInit(int version, void* raw_driver,
+                                    struct AdbcError* error) {
+  if (version != ADBC_VERSION_1_0_0 && version != ADBC_VERSION_1_1_0) {
+    return ADBC_STATUS_NOT_IMPLEMENTED;
+  }
+  if (!raw_driver) return ADBC_STATUS_INVALID_ARGUMENT;
+
+  auto* driver = reinterpret_cast<struct AdbcDriver*>(raw_driver);
+  if (version >= ADBC_VERSION_1_1_0) {
+    std::memset(driver, 0, ADBC_DRIVER_1_1_0_SIZE);
+
+    driver->ErrorGetDetailCount = CommonErrorGetDetailCount;
+    driver->ErrorGetDetail = CommonErrorGetDetail;
+    driver->ErrorFromArrayStream = PostgresErrorFromArrayStream;
+
+    driver->DatabaseGetOption = PostgresDatabaseGetOption;
+    driver->DatabaseGetOptionBytes = PostgresDatabaseGetOptionBytes;
+    driver->DatabaseGetOptionDouble = PostgresDatabaseGetOptionDouble;
+    driver->DatabaseGetOptionInt = PostgresDatabaseGetOptionInt;
+    driver->DatabaseSetOptionBytes = PostgresDatabaseSetOptionBytes;
+    driver->DatabaseSetOptionDouble = PostgresDatabaseSetOptionDouble;
+    driver->DatabaseSetOptionInt = PostgresDatabaseSetOptionInt;
+
+    driver->ConnectionCancel = PostgresConnectionCancel;
+    driver->ConnectionGetOption = PostgresConnectionGetOption;
+    driver->ConnectionGetOptionBytes = PostgresConnectionGetOptionBytes;
+    driver->ConnectionGetOptionDouble = PostgresConnectionGetOptionDouble;
+    driver->ConnectionGetOptionInt = PostgresConnectionGetOptionInt;
+    driver->ConnectionGetStatistics = PostgresConnectionGetStatistics;
+    driver->ConnectionGetStatisticNames = PostgresConnectionGetStatisticNames;
+    driver->ConnectionSetOptionBytes = PostgresConnectionSetOptionBytes;
+    driver->ConnectionSetOptionDouble = PostgresConnectionSetOptionDouble;
+    driver->ConnectionSetOptionInt = PostgresConnectionSetOptionInt;
+
+    driver->StatementCancel = PostgresStatementCancel;
+    driver->StatementExecuteSchema = PostgresStatementExecuteSchema;
+    driver->StatementGetOption = PostgresStatementGetOption;
+    driver->StatementGetOptionBytes = PostgresStatementGetOptionBytes;
+    driver->StatementGetOptionDouble = PostgresStatementGetOptionDouble;
+    driver->StatementGetOptionInt = PostgresStatementGetOptionInt;
+    driver->StatementSetOptionBytes = PostgresStatementSetOptionBytes;
+    driver->StatementSetOptionDouble = PostgresStatementSetOptionDouble;
+    driver->StatementSetOptionInt = PostgresStatementSetOptionInt;
+  } else {
+    std::memset(driver, 0, ADBC_DRIVER_1_0_0_SIZE);
+  }
+
+  driver->DatabaseInit = PostgresDatabaseInit;
+  driver->DatabaseNew = PostgresDatabaseNew;
+  driver->DatabaseRelease = PostgresDatabaseRelease;
+  driver->DatabaseSetOption = PostgresDatabaseSetOption;
+
+  driver->ConnectionCommit = PostgresConnectionCommit;
+  driver->ConnectionGetInfo = PostgresConnectionGetInfo;
+  driver->ConnectionGetObjects = PostgresConnectionGetObjects;
+  driver->ConnectionGetTableSchema = PostgresConnectionGetTableSchema;
+  driver->ConnectionGetTableTypes = PostgresConnectionGetTableTypes;
+  driver->ConnectionInit = PostgresConnectionInit;
+  driver->ConnectionNew = PostgresConnectionNew;
+  driver->ConnectionReadPartition = PostgresConnectionReadPartition;
+  driver->ConnectionRelease = PostgresConnectionRelease;
+  driver->ConnectionRollback = PostgresConnectionRollback;
+  driver->ConnectionSetOption = PostgresConnectionSetOption;
+
+  driver->StatementBind = PostgresStatementBind;
+  driver->StatementBindStream = PostgresStatementBindStream;
+  driver->StatementExecutePartitions = PostgresStatementExecutePartitions;
+  driver->StatementExecuteQuery = PostgresStatementExecuteQuery;
+  driver->StatementGetParameterSchema = PostgresStatementGetParameterSchema;
+  driver->StatementNew = PostgresStatementNew;
+  driver->StatementPrepare = PostgresStatementPrepare;
+  driver->StatementRelease = PostgresStatementRelease;
+  driver->StatementSetOption = PostgresStatementSetOption;
+  driver->StatementSetSqlQuery = PostgresStatementSetSqlQuery;
+
+  return ADBC_STATUS_OK;
+}
+
+ADBC_EXPORT
+AdbcStatusCode AdbcDriverInit(int version, void* raw_driver, struct AdbcError* error) {
+  return PostgresqlDriverInit(version, raw_driver, error);
+}
+}

--- a/c/driver/netezza/postgresql_benchmark.cc
+++ b/c/driver/netezza/postgresql_benchmark.cc
@@ -1,0 +1,179 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+#include <benchmark/benchmark.h>
+#include <nanoarrow/nanoarrow.hpp>
+
+#include "adbc.h"
+#include "validation/adbc_validation_util.h"
+
+#define _ADBC_BENCHMARK_RETURN_NOT_OK_IMPL(NAME, EXPR) \
+  do {                                                 \
+    const int NAME = (EXPR);                           \
+    if (NAME) {                                        \
+      state.SkipWithError(error.message);              \
+      error.release(&error);                           \
+      return;                                          \
+    }                                                  \
+  } while (0)
+
+#define ADBC_BENCHMARK_RETURN_NOT_OK(EXPR) \
+  _ADBC_BENCHMARK_RETURN_NOT_OK_IMPL(_NANOARROW_MAKE_NAME(errno_status_, \
+                                                          __COUNTER__), EXPR)
+
+
+static void BM_PostgresqlExecute(benchmark::State& state) {
+  const char* uri = std::getenv("ADBC_POSTGRESQL_TEST_URI");
+  if (!uri || !strcmp(uri, "")) {
+    state.SkipWithError("ADBC_POSTGRESQL_TEST_URI not set!");
+    return;
+  }
+  adbc_validation::Handle<struct AdbcDatabase> database;
+  struct AdbcError error;
+
+  ADBC_BENCHMARK_RETURN_NOT_OK(AdbcDatabaseNew(&database.value, &error));
+  ADBC_BENCHMARK_RETURN_NOT_OK(AdbcDatabaseSetOption(&database.value,
+                                                     "uri",
+                                                     uri,
+                                                     &error));
+  ADBC_BENCHMARK_RETURN_NOT_OK(AdbcDatabaseInit(&database.value, &error));
+
+  adbc_validation::Handle<struct AdbcConnection> connection;
+  ADBC_BENCHMARK_RETURN_NOT_OK(AdbcConnectionNew(&connection.value, &error));
+  ADBC_BENCHMARK_RETURN_NOT_OK(AdbcConnectionInit(&connection.value,
+                                                  &database.value,
+                                                  &error));
+
+  adbc_validation::Handle<struct AdbcStatement> statement;
+  ADBC_BENCHMARK_RETURN_NOT_OK(AdbcStatementNew(&connection.value,
+                                                &statement.value,
+                                                &error));
+
+  const char* drop_query = "DROP TABLE IF EXISTS adbc_postgresql_ingest_benchmark";
+  ADBC_BENCHMARK_RETURN_NOT_OK(AdbcStatementSetSqlQuery(&statement.value,
+                                                        drop_query,
+                                                        &error));
+
+  ADBC_BENCHMARK_RETURN_NOT_OK(AdbcStatementExecuteQuery(&statement.value,
+                                                         nullptr,
+                                                         nullptr,
+                                                         &error));
+
+  adbc_validation::Handle<struct ArrowSchema> schema;
+  adbc_validation::Handle<struct ArrowArray> array;
+  struct ArrowError na_error;
+
+  ADBC_BENCHMARK_RETURN_NOT_OK(adbc_validation::MakeSchema(&schema.value, {
+        {"bools", NANOARROW_TYPE_BOOL},
+        {"int16s", NANOARROW_TYPE_INT16},
+        {"int32s", NANOARROW_TYPE_INT32},
+        {"int64s", NANOARROW_TYPE_INT64},
+        {"floats", NANOARROW_TYPE_FLOAT},
+        {"doubles", NANOARROW_TYPE_DOUBLE},
+      }));
+
+  if (ArrowArrayInitFromSchema(&array.value, &schema.value, &na_error) != NANOARROW_OK) {
+    state.SkipWithError("Call to ArrowArrayInitFromSchema failed!");
+    error.release(&error);
+    return;
+  }
+
+  if (ArrowArrayStartAppending(&array.value) != NANOARROW_OK) {
+    state.SkipWithError("Call to ArrowArrayStartAppending failed!");
+    error.release(&error);
+    return;
+  }
+
+  const size_t n_zeros = 1000;
+  const size_t n_ones = 1000;
+
+  for (size_t i = 0; i < n_zeros; i++) {
+    // assumes fixed size primitive layouts for now
+    ArrowBufferAppendInt8(ArrowArrayBuffer(array.value.children[0], 1), 0);
+    ArrowBufferAppendInt16(ArrowArrayBuffer(array.value.children[1], 1), 0);
+    ArrowBufferAppendInt32(ArrowArrayBuffer(array.value.children[2], 1), 0);
+    ArrowBufferAppendInt64(ArrowArrayBuffer(array.value.children[3], 1), 0);
+    ArrowBufferAppendFloat(ArrowArrayBuffer(array.value.children[4], 1), 0.0);
+    ArrowBufferAppendDouble(ArrowArrayBuffer(array.value.children[5], 1), 0.0);
+  }
+  for (size_t i = 0; i < n_ones; i++) {
+    // assumes fixed size primitive layouts for now
+    ArrowBufferAppendInt8(ArrowArrayBuffer(array.value.children[0], 1), 1);
+    ArrowBufferAppendInt16(ArrowArrayBuffer(array.value.children[1], 1), 1);
+    ArrowBufferAppendInt32(ArrowArrayBuffer(array.value.children[2], 1), 1);
+    ArrowBufferAppendInt64(ArrowArrayBuffer(array.value.children[3], 1), 1);
+    ArrowBufferAppendFloat(ArrowArrayBuffer(array.value.children[4], 1), 1.0);
+    ArrowBufferAppendDouble(ArrowArrayBuffer(array.value.children[5], 1), 1.0);
+  }
+
+  for (int64_t i = 0; i < array.value.n_children; i++) {
+    array.value.children[i]->length = n_zeros + n_ones;
+  }
+  array.value.length = n_zeros + n_ones;
+
+  if (ArrowArrayFinishBuildingDefault(&array.value, &na_error) != NANOARROW_OK) {
+    state.SkipWithError("Call to ArrowArrayFinishBuildingDefault failed");
+    error.release(&error);
+    return;
+  }
+
+  const char* create_query =
+    "CREATE TABLE adbc_postgresql_ingest_benchmark (bools BOOLEAN, int16s SMALLINT, "
+    "int32s INTEGER, int64s BIGINT, floats REAL, doubles DOUBLE PRECISION)";
+
+  ADBC_BENCHMARK_RETURN_NOT_OK(AdbcStatementSetSqlQuery(&statement.value,
+                                                        create_query,
+                                                        &error));
+
+  ADBC_BENCHMARK_RETURN_NOT_OK(AdbcStatementExecuteQuery(&statement.value,
+                                                         nullptr,
+                                                         nullptr,
+                                                         &error));
+
+  adbc_validation::Handle<struct AdbcStatement> insert_stmt;
+  ADBC_BENCHMARK_RETURN_NOT_OK(AdbcStatementNew(&connection.value,
+                                                &insert_stmt.value,
+                                                &error));
+
+  ADBC_BENCHMARK_RETURN_NOT_OK(AdbcStatementSetOption(&insert_stmt.value,
+                                                      ADBC_INGEST_OPTION_TARGET_TABLE,
+                                                      "adbc_postgresql_ingest_benchmark",
+                                                      &error));
+
+  ADBC_BENCHMARK_RETURN_NOT_OK(AdbcStatementSetOption(&insert_stmt.value,
+                                                      ADBC_INGEST_OPTION_MODE,
+                                                      ADBC_INGEST_OPTION_MODE_APPEND,
+                                                      &error));
+
+  for (auto _ : state) {
+    AdbcStatementBind(&insert_stmt.value, &array.value, &schema.value, &error);
+    AdbcStatementExecuteQuery(&insert_stmt.value, nullptr, nullptr, &error);
+  }
+
+  ADBC_BENCHMARK_RETURN_NOT_OK(AdbcStatementSetSqlQuery(&statement.value,
+                                                        drop_query,
+                                                        &error));
+
+  ADBC_BENCHMARK_RETURN_NOT_OK(AdbcStatementExecuteQuery(&statement.value,
+                                                         nullptr,
+                                                         nullptr,
+                                                         &error));
+}
+
+BENCHMARK(BM_PostgresqlExecute)->Iterations(1);
+BENCHMARK_MAIN();

--- a/c/driver/netezza/postgresql_test.cc
+++ b/c/driver/netezza/postgresql_test.cc
@@ -1,0 +1,1647 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <cerrno>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <limits>
+#include <optional>
+#include <variant>
+
+#include <adbc.h>
+#include <gtest/gtest-param-test.h>
+#include <gtest/gtest.h>
+#include <nanoarrow/nanoarrow.h>
+
+#include "common/options.h"
+#include "common/utils.h"
+#include "database.h"
+#include "validation/adbc_validation.h"
+#include "validation/adbc_validation_util.h"
+
+using adbc_validation::Handle;
+using adbc_validation::IsOkStatus;
+using adbc_validation::IsStatus;
+
+class PostgresQuirks : public adbc_validation::DriverQuirks {
+ public:
+  AdbcStatusCode SetupDatabase(struct AdbcDatabase* database,
+                               struct AdbcError* error) const override {
+    const char* uri = std::getenv("ADBC_POSTGRESQL_TEST_URI");
+    if (!uri) {
+      ADD_FAILURE() << "Must provide env var ADBC_POSTGRESQL_TEST_URI";
+      return ADBC_STATUS_INVALID_ARGUMENT;
+    }
+    return AdbcDatabaseSetOption(database, "uri", uri, error);
+  }
+
+  AdbcStatusCode DropTable(struct AdbcConnection* connection, const std::string& name,
+                           struct AdbcError* error) const override {
+    Handle<struct AdbcStatement> statement;
+    RAISE_ADBC(AdbcStatementNew(connection, &statement.value, error));
+
+    std::string query = "DROP TABLE IF EXISTS \"" + name + "\"";
+    RAISE_ADBC(AdbcStatementSetSqlQuery(&statement.value, query.c_str(), error));
+    RAISE_ADBC(AdbcStatementExecuteQuery(&statement.value, nullptr, nullptr, error));
+    return AdbcStatementRelease(&statement.value, error);
+  }
+
+  AdbcStatusCode DropTable(struct AdbcConnection* connection, const std::string& name,
+                           const std::string& db_schema,
+                           struct AdbcError* error) const override {
+    Handle<struct AdbcStatement> statement;
+    RAISE_ADBC(AdbcStatementNew(connection, &statement.value, error));
+
+    std::string query = "DROP TABLE IF EXISTS \"" + db_schema + "\".\"" + name + "\"";
+    RAISE_ADBC(AdbcStatementSetSqlQuery(&statement.value, query.c_str(), error));
+    RAISE_ADBC(AdbcStatementExecuteQuery(&statement.value, nullptr, nullptr, error));
+    return AdbcStatementRelease(&statement.value, error);
+  }
+
+  AdbcStatusCode DropTempTable(struct AdbcConnection* connection, const std::string& name,
+                               struct AdbcError* error) const override {
+    Handle<struct AdbcStatement> statement;
+    RAISE_ADBC(AdbcStatementNew(connection, &statement.value, error));
+
+    std::string query = "DROP TABLE IF EXISTS pg_temp . \"" + name + "\"";
+    RAISE_ADBC(AdbcStatementSetSqlQuery(&statement.value, query.c_str(), error));
+    RAISE_ADBC(AdbcStatementExecuteQuery(&statement.value, nullptr, nullptr, error));
+    return AdbcStatementRelease(&statement.value, error);
+  }
+
+  AdbcStatusCode DropView(struct AdbcConnection* connection, const std::string& name,
+                          struct AdbcError* error) const override {
+    Handle<struct AdbcStatement> statement;
+    RAISE_ADBC(AdbcStatementNew(connection, &statement.value, error));
+
+    std::string query = "DROP VIEW IF EXISTS \"" + name + "\"";
+    RAISE_ADBC(AdbcStatementSetSqlQuery(&statement.value, query.c_str(), error));
+    RAISE_ADBC(AdbcStatementExecuteQuery(&statement.value, nullptr, nullptr, error));
+    return AdbcStatementRelease(&statement.value, error);
+  }
+
+  AdbcStatusCode EnsureDbSchema(struct AdbcConnection* connection,
+                                const std::string& name,
+                                struct AdbcError* error) const override {
+    Handle<struct AdbcStatement> statement;
+    RAISE_ADBC(AdbcStatementNew(connection, &statement.value, error));
+
+    std::string query = "CREATE SCHEMA IF NOT EXISTS \"" + name + "\"";
+    RAISE_ADBC(AdbcStatementSetSqlQuery(&statement.value, query.c_str(), error));
+    RAISE_ADBC(AdbcStatementExecuteQuery(&statement.value, nullptr, nullptr, error));
+    return AdbcStatementRelease(&statement.value, error);
+  }
+
+  std::string BindParameter(int index) const override {
+    return "$" + std::to_string(index + 1);
+  }
+
+  ArrowType IngestSelectRoundTripType(ArrowType ingest_type) const override {
+    switch (ingest_type) {
+      case NANOARROW_TYPE_INT8:
+        return NANOARROW_TYPE_INT16;
+      case NANOARROW_TYPE_DURATION:
+        return NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO;
+      case NANOARROW_TYPE_LARGE_STRING:
+        return NANOARROW_TYPE_STRING;
+      default:
+        return ingest_type;
+    }
+  }
+
+  std::optional<std::string> PrimaryKeyTableDdl(std::string_view name) const override {
+    std::string ddl = "CREATE TABLE ";
+    ddl += name;
+    ddl += " (id SERIAL PRIMARY KEY)";
+    return ddl;
+  }
+
+  std::optional<std::string> PrimaryKeyIngestTableDdl(
+      std::string_view name) const override {
+    std::string ddl = "CREATE TABLE ";
+    ddl += name;
+    ddl += " (id BIGSERIAL PRIMARY KEY, value BIGINT)";
+    return ddl;
+  }
+
+  std::optional<std::string> CompositePrimaryKeyTableDdl(
+      std::string_view name) const override {
+    std::string ddl = "CREATE TABLE ";
+    ddl += name;
+    ddl += " (id_primary_col1 SERIAL, id_primary_col2 SERIAL,";
+    ddl += " PRIMARY KEY (id_primary_col1, id_primary_col2));";
+    return ddl;
+  }
+
+  std::optional<std::string> ForeignKeyChildTableDdl(
+      std::string_view child_name, std::string_view parent_name_1,
+      std::string_view parent_name_2) const override {
+    std::string ddl = "CREATE TABLE ";
+    ddl += child_name;
+    ddl += " (id_child_col1 SERIAL PRIMARY KEY, ";
+    ddl += " id_child_col2 SERIAL, ";
+    ddl += " id_child_col3 SERIAL, ";
+    ddl += " FOREIGN KEY (id_child_col3) REFERENCES ";
+    ddl += parent_name_1;
+    ddl += " (id),";
+    ddl += " FOREIGN KEY (id_child_col1, id_child_col2) REFERENCES ";
+    ddl += parent_name_2;
+    ddl += " (id_primary_col1, id_primary_col2))";
+    return ddl;
+  }
+
+  std::string catalog() const override { return "postgres"; }
+  std::string db_schema() const override { return "public"; }
+
+  bool supports_bulk_ingest_catalog() const override { return false; }
+  bool supports_bulk_ingest_db_schema() const override { return true; }
+  bool supports_bulk_ingest_temporary() const override { return true; }
+  bool supports_cancel() const override { return true; }
+  bool supports_execute_schema() const override { return true; }
+  std::optional<adbc_validation::SqlInfoValue> supports_get_sql_info(
+      uint32_t info_code) const override {
+    switch (info_code) {
+      case ADBC_INFO_DRIVER_ADBC_VERSION:
+        return ADBC_VERSION_1_1_0;
+      case ADBC_INFO_DRIVER_NAME:
+        return "ADBC PostgreSQL Driver";
+      case ADBC_INFO_DRIVER_VERSION:
+        return "(unknown)";
+      case ADBC_INFO_VENDOR_NAME:
+        return "PostgreSQL";
+      default:
+        return std::nullopt;
+    }
+  }
+  bool supports_metadata_current_catalog() const override { return true; }
+  bool supports_metadata_current_db_schema() const override { return true; }
+  bool supports_statistics() const override { return true; }
+};
+
+class PostgresDatabaseTest : public ::testing::Test,
+                             public adbc_validation::DatabaseTest {
+ public:
+  const adbc_validation::DriverQuirks* quirks() const override { return &quirks_; }
+  void SetUp() override { ASSERT_NO_FATAL_FAILURE(SetUpTest()); }
+  void TearDown() override { ASSERT_NO_FATAL_FAILURE(TearDownTest()); }
+
+ protected:
+  PostgresQuirks quirks_;
+};
+ADBCV_TEST_DATABASE(PostgresDatabaseTest)
+
+TEST_F(PostgresDatabaseTest, AdbcDriverBackwardsCompatibility) {
+  // XXX: sketchy cast
+  auto* driver = static_cast<struct AdbcDriver*>(malloc(ADBC_DRIVER_1_0_0_SIZE));
+  std::memset(driver, 0, ADBC_DRIVER_1_0_0_SIZE);
+
+  ASSERT_THAT(::PostgresqlDriverInit(ADBC_VERSION_1_0_0, driver, &error),
+              IsOkStatus(&error));
+
+  ASSERT_THAT(::PostgresqlDriverInit(424242, driver, &error),
+              IsStatus(ADBC_STATUS_NOT_IMPLEMENTED, &error));
+
+  free(driver);
+}
+
+class PostgresConnectionTest : public ::testing::Test,
+                               public adbc_validation::ConnectionTest {
+ public:
+  const adbc_validation::DriverQuirks* quirks() const override { return &quirks_; }
+  void SetUp() override { ASSERT_NO_FATAL_FAILURE(SetUpTest()); }
+  void TearDown() override { ASSERT_NO_FATAL_FAILURE(TearDownTest()); }
+
+ protected:
+  PostgresQuirks quirks_;
+};
+
+TEST_F(PostgresConnectionTest, GetInfoMetadata) {
+  ASSERT_THAT(AdbcConnectionNew(&connection, &error), IsOkStatus(&error));
+  ASSERT_THAT(AdbcConnectionInit(&connection, &database, &error), IsOkStatus(&error));
+
+  adbc_validation::StreamReader reader;
+  std::vector<uint32_t> info = {
+      ADBC_INFO_DRIVER_NAME, ADBC_INFO_DRIVER_VERSION, ADBC_INFO_DRIVER_ADBC_VERSION,
+      ADBC_INFO_VENDOR_NAME, ADBC_INFO_VENDOR_VERSION,
+  };
+  ASSERT_THAT(AdbcConnectionGetInfo(&connection, info.data(), info.size(),
+                                    &reader.stream.value, &error),
+              IsOkStatus(&error));
+  ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+
+  std::vector<uint32_t> seen;
+  while (true) {
+    ASSERT_NO_FATAL_FAILURE(reader.Next());
+    if (!reader.array->release) break;
+
+    for (int64_t row = 0; row < reader.array->length; row++) {
+      ASSERT_FALSE(ArrowArrayViewIsNull(reader.array_view->children[0], row));
+      const uint32_t code =
+          reader.array_view->children[0]->buffer_views[1].data.as_uint32[row];
+      const uint32_t offset =
+          reader.array_view->children[1]->buffer_views[1].data.as_int32[row];
+      seen.push_back(code);
+
+      struct ArrowArrayView* str_child = reader.array_view->children[1]->children[0];
+      struct ArrowArrayView* int_child = reader.array_view->children[1]->children[2];
+      switch (code) {
+        case ADBC_INFO_DRIVER_NAME: {
+          ArrowStringView val = ArrowArrayViewGetStringUnsafe(str_child, offset);
+          EXPECT_EQ("ADBC PostgreSQL Driver", std::string(val.data, val.size_bytes));
+          break;
+        }
+        case ADBC_INFO_DRIVER_VERSION: {
+          ArrowStringView val = ArrowArrayViewGetStringUnsafe(str_child, offset);
+          EXPECT_EQ("(unknown)", std::string(val.data, val.size_bytes));
+          break;
+        }
+        case ADBC_INFO_VENDOR_NAME: {
+          ArrowStringView val = ArrowArrayViewGetStringUnsafe(str_child, offset);
+          EXPECT_EQ("PostgreSQL", std::string(val.data, val.size_bytes));
+          break;
+        }
+        case ADBC_INFO_VENDOR_VERSION: {
+          ArrowStringView val = ArrowArrayViewGetStringUnsafe(str_child, offset);
+#ifdef __WIN32
+          const char* pater = "\\d\\d\\d\\d\\d\\d";
+#else
+          const char* pater = "[0-9]{6}";
+#endif
+          EXPECT_THAT(std::string(val.data, val.size_bytes),
+                      ::testing::MatchesRegex(pater));
+          break;
+        }
+        case ADBC_INFO_DRIVER_ADBC_VERSION: {
+          EXPECT_EQ(ADBC_VERSION_1_1_0, ArrowArrayViewGetIntUnsafe(int_child, offset));
+          break;
+        }
+        default:
+          // Ignored
+          break;
+      }
+    }
+  }
+  ASSERT_THAT(seen, ::testing::UnorderedElementsAreArray(info));
+}
+
+TEST_F(PostgresConnectionTest, GetObjectsGetCatalogs) {
+  ASSERT_THAT(AdbcConnectionNew(&connection, &error), IsOkStatus(&error));
+  ASSERT_THAT(AdbcConnectionInit(&connection, &database, &error), IsOkStatus(&error));
+
+  adbc_validation::StreamReader reader;
+  ASSERT_THAT(
+      AdbcConnectionGetObjects(&connection, ADBC_OBJECT_DEPTH_CATALOGS, nullptr, nullptr,
+                               nullptr, nullptr, nullptr, &reader.stream.value, &error),
+      IsOkStatus(&error));
+  ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+  ASSERT_NO_FATAL_FAILURE(reader.Next());
+  ASSERT_NE(nullptr, reader.array->release);
+  ASSERT_GT(reader.array->length, 0);
+
+  auto get_objects_data = adbc_validation::GetObjectsReader{&reader.array_view.value};
+  ASSERT_NE(*get_objects_data, nullptr)
+      << "could not initialize the AdbcGetObjectsData object";
+
+  auto catalogs = {"postgres", "template0", "template1"};
+  for (auto catalog : catalogs) {
+    struct AdbcGetObjectsCatalog* cat =
+        AdbcGetObjectsDataGetCatalogByName(*get_objects_data, catalog);
+    ASSERT_NE(cat, nullptr) << "catalog " << catalog << " not found";
+  }
+}
+
+TEST_F(PostgresConnectionTest, GetObjectsGetDbSchemas) {
+  ASSERT_THAT(AdbcConnectionNew(&connection, &error), IsOkStatus(&error));
+  ASSERT_THAT(AdbcConnectionInit(&connection, &database, &error), IsOkStatus(&error));
+
+  adbc_validation::StreamReader reader;
+  ASSERT_THAT(AdbcConnectionGetObjects(&connection, ADBC_OBJECT_DEPTH_DB_SCHEMAS, nullptr,
+                                       nullptr, nullptr, nullptr, nullptr,
+                                       &reader.stream.value, &error),
+              IsOkStatus(&error));
+  ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+  ASSERT_NO_FATAL_FAILURE(reader.Next());
+  ASSERT_NE(nullptr, reader.array->release);
+  ASSERT_GT(reader.array->length, 0);
+
+  auto get_objects_data = adbc_validation::GetObjectsReader{&reader.array_view.value};
+  ASSERT_NE(*get_objects_data, nullptr)
+      << "could not initialize the AdbcGetObjectsData object";
+
+  struct AdbcGetObjectsSchema* schema =
+      AdbcGetObjectsDataGetSchemaByName(*get_objects_data, "postgres", "public");
+  ASSERT_NE(schema, nullptr) << "schema public not found";
+}
+
+TEST_F(PostgresConnectionTest, GetObjectsGetAllFindsPrimaryKey) {
+  ASSERT_THAT(AdbcConnectionNew(&connection, &error), IsOkStatus(&error));
+  ASSERT_THAT(AdbcConnectionInit(&connection, &database, &error), IsOkStatus(&error));
+
+  ASSERT_THAT(quirks()->DropTable(&connection, "adbc_pkey_test", &error),
+              IsOkStatus(&error));
+
+  struct AdbcStatement statement;
+  ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
+  {
+    ASSERT_THAT(
+        AdbcStatementSetSqlQuery(
+            &statement, "CREATE TABLE adbc_pkey_test (ints INT, id SERIAL PRIMARY KEY)",
+            &error),
+        IsOkStatus(&error));
+    adbc_validation::StreamReader reader;
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                          &reader.rows_affected, &error),
+                IsOkStatus(&error));
+    ASSERT_EQ(reader.rows_affected, -1);
+    ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+    ASSERT_NO_FATAL_FAILURE(reader.Next());
+    ASSERT_EQ(reader.array->release, nullptr);
+  }
+  ASSERT_THAT(AdbcStatementRelease(&statement, &error), IsOkStatus(&error));
+
+  adbc_validation::StreamReader reader;
+  ASSERT_THAT(
+      AdbcConnectionGetObjects(&connection, ADBC_OBJECT_DEPTH_ALL, nullptr, nullptr,
+                               nullptr, nullptr, nullptr, &reader.stream.value, &error),
+      IsOkStatus(&error));
+  ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+  ASSERT_NO_FATAL_FAILURE(reader.Next());
+  ASSERT_NE(nullptr, reader.array->release);
+  ASSERT_GT(reader.array->length, 0);
+
+  auto get_objects_data = adbc_validation::GetObjectsReader{&reader.array_view.value};
+  ASSERT_NE(*get_objects_data, nullptr)
+      << "could not initialize the AdbcGetObjectsData object";
+
+  struct AdbcGetObjectsTable* table = AdbcGetObjectsDataGetTableByName(
+      *get_objects_data, "postgres", "public", "adbc_pkey_test");
+  ASSERT_NE(table, nullptr) << "could not find adbc_pkey_test table";
+
+  ASSERT_EQ(table->n_table_columns, 2);
+  struct AdbcGetObjectsColumn* column = AdbcGetObjectsDataGetColumnByName(
+      *get_objects_data, "postgres", "public", "adbc_pkey_test", "id");
+  ASSERT_NE(column, nullptr) << "could not find id column on adbc_pkey_test table";
+
+  ASSERT_EQ(table->n_table_constraints, 1)
+      << "expected 1 constraint on adbc_pkey_test table, found: "
+      << table->n_table_constraints;
+
+  struct AdbcGetObjectsConstraint* constraint = AdbcGetObjectsDataGetConstraintByName(
+      *get_objects_data, "postgres", "public", "adbc_pkey_test", "adbc_pkey_test_pkey");
+  ASSERT_NE(constraint, nullptr) << "could not find adbc_pkey_test_pkey constraint";
+
+  auto constraint_type = std::string(constraint->constraint_type.data,
+                                     constraint->constraint_type.size_bytes);
+  ASSERT_EQ(constraint_type, "PRIMARY KEY");
+  ASSERT_EQ(constraint->n_column_names, 1)
+      << "expected constraint adbc_pkey_test_pkey to be applied to 1 column, found: "
+      << constraint->n_column_names;
+
+  auto constraint_column_name =
+      std::string(constraint->constraint_column_names[0].data,
+                  constraint->constraint_column_names[0].size_bytes);
+  ASSERT_EQ(constraint_column_name, "id");
+}
+
+TEST_F(PostgresConnectionTest, GetObjectsGetAllFindsForeignKey) {
+  ASSERT_THAT(AdbcConnectionNew(&connection, &error), IsOkStatus(&error));
+  ASSERT_THAT(AdbcConnectionInit(&connection, &database, &error), IsOkStatus(&error));
+
+  ASSERT_THAT(quirks()->DropTable(&connection, "adbc_fkey_test", &error),
+              IsOkStatus(&error));
+  ASSERT_THAT(quirks()->DropTable(&connection, "adbc_fkey_test_base", &error),
+              IsOkStatus(&error));
+
+  struct AdbcStatement statement;
+  ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
+  {
+    ASSERT_THAT(
+        AdbcStatementSetSqlQuery(&statement,
+                                 "CREATE TABLE adbc_fkey_test_base (id1 INT, id2 INT, "
+                                 "PRIMARY KEY (id1, id2))",
+                                 &error),
+        IsOkStatus(&error));
+    adbc_validation::StreamReader reader;
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                          &reader.rows_affected, &error),
+                IsOkStatus(&error));
+    ASSERT_EQ(reader.rows_affected, -1);
+    ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+    ASSERT_NO_FATAL_FAILURE(reader.Next());
+    ASSERT_EQ(reader.array->release, nullptr);
+  }
+  ASSERT_THAT(AdbcStatementRelease(&statement, &error), IsOkStatus(&error));
+
+  ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
+  {
+    ASSERT_THAT(AdbcStatementSetSqlQuery(
+                    &statement,
+                    "CREATE TABLE adbc_fkey_test (fid1 INT, fid2 INT, "
+                    "FOREIGN KEY (fid1, fid2) REFERENCES adbc_fkey_test_base(id1, id2))",
+                    &error),
+                IsOkStatus(&error));
+    adbc_validation::StreamReader reader;
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                          &reader.rows_affected, &error),
+                IsOkStatus(&error));
+    ASSERT_EQ(reader.rows_affected, -1);
+    ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+    ASSERT_NO_FATAL_FAILURE(reader.Next());
+    ASSERT_EQ(reader.array->release, nullptr);
+  }
+  ASSERT_THAT(AdbcStatementRelease(&statement, &error), IsOkStatus(&error));
+
+  adbc_validation::StreamReader reader;
+  ASSERT_THAT(
+      AdbcConnectionGetObjects(&connection, ADBC_OBJECT_DEPTH_ALL, nullptr, nullptr,
+                               nullptr, nullptr, nullptr, &reader.stream.value, &error),
+      IsOkStatus(&error));
+  ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+  ASSERT_NO_FATAL_FAILURE(reader.Next());
+  ASSERT_NE(nullptr, reader.array->release);
+  ASSERT_GT(reader.array->length, 0);
+
+  auto get_objects_data = adbc_validation::GetObjectsReader{&reader.array_view.value};
+  ASSERT_NE(*get_objects_data, nullptr)
+      << "could not initialize the AdbcGetInfoData object";
+
+  struct AdbcGetObjectsTable* table = AdbcGetObjectsDataGetTableByName(
+      *get_objects_data, "postgres", "public", "adbc_fkey_test");
+  ASSERT_NE(table, nullptr) << "could not find adbc_fkey_test table";
+  ASSERT_EQ(table->n_table_constraints, 1)
+      << "expected 1 constraint on adbc_fkey_test table, found: "
+      << table->n_table_constraints;
+
+  const std::string version = adbc_validation::GetDriverVendorVersion(&connection);
+  const std::string search_name =
+      version < "120000" ? "adbc_fkey_test_fid1_fkey" : "adbc_fkey_test_fid1_fid2_fkey";
+  struct AdbcGetObjectsConstraint* constraint = AdbcGetObjectsDataGetConstraintByName(
+      *get_objects_data, "postgres", "public", "adbc_fkey_test", search_name.c_str());
+  ASSERT_NE(constraint, nullptr) << "could not find " << search_name << " constraint";
+
+  auto constraint_type = std::string(constraint->constraint_type.data,
+                                     constraint->constraint_type.size_bytes);
+  ASSERT_EQ(constraint_type, "FOREIGN KEY");
+  ASSERT_EQ(constraint->n_column_names, 2)
+      << "expected constraint adbc_fkey_test_fid1_fid2_fkey to be applied to 2 columns, "
+         "found: "
+      << constraint->n_column_names;
+
+  for (auto i = 0; i < 2; i++) {
+    auto str_vw = constraint->constraint_column_names[i];
+    auto str = std::string(str_vw.data, str_vw.size_bytes);
+    if (i == 0) {
+      ASSERT_EQ(str, "fid1");
+    } else if (i == 1) {
+      ASSERT_EQ(str, "fid2");
+    }
+  }
+
+  ASSERT_EQ(constraint->n_column_usages, 2)
+      << "expected constraint adbc_fkey_test_fid1_fid2_fkey to have 2 usages, found: "
+      << constraint->n_column_usages;
+
+  for (auto i = 0; i < 2; i++) {
+    struct AdbcGetObjectsUsage* usage = constraint->constraint_column_usages[i];
+    auto catalog_str = std::string(usage->fk_catalog.data, usage->fk_catalog.size_bytes);
+    ASSERT_EQ(catalog_str, "postgres");
+    auto schema_str =
+        std::string(usage->fk_db_schema.data, usage->fk_db_schema.size_bytes);
+    ASSERT_EQ(schema_str, "public");
+    auto table_str = std::string(usage->fk_table.data, usage->fk_table.size_bytes);
+    ASSERT_EQ(table_str, "adbc_fkey_test_base");
+
+    auto column_str =
+        std::string(usage->fk_column_name.data, usage->fk_column_name.size_bytes);
+    if (i == 0) {
+      ASSERT_EQ(column_str, "id1");
+    } else if (i == 1) {
+      ASSERT_EQ(column_str, "id2");
+    }
+  }
+}
+
+TEST_F(PostgresConnectionTest, GetObjectsTableTypesFilter) {
+  ASSERT_THAT(AdbcConnectionNew(&connection, &error), IsOkStatus(&error));
+  ASSERT_THAT(AdbcConnectionInit(&connection, &database, &error), IsOkStatus(&error));
+
+  ASSERT_THAT(quirks()->DropView(&connection, "adbc_table_types_view_test", &error),
+              IsOkStatus(&error));
+  ASSERT_THAT(quirks()->DropTable(&connection, "adbc_table_types_table_test", &error),
+              IsOkStatus(&error));
+
+  {
+    adbc_validation::Handle<struct AdbcStatement> statement;
+    ASSERT_THAT(AdbcStatementNew(&connection, &statement.value, &error),
+                IsOkStatus(&error));
+
+    ASSERT_THAT(
+        AdbcStatementSetSqlQuery(
+            &statement.value,
+            "CREATE TABLE adbc_table_types_table_test (id1 INT, id2 INT)", &error),
+        IsOkStatus(&error));
+
+    int64_t rows_affected = 0;
+    ASSERT_THAT(
+        AdbcStatementExecuteQuery(&statement.value, nullptr, &rows_affected, &error),
+        IsOkStatus(&error));
+  }
+
+  {
+    adbc_validation::Handle<struct AdbcStatement> statement;
+    ASSERT_THAT(AdbcStatementNew(&connection, &statement.value, &error),
+                IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementSetSqlQuery(&statement.value,
+                                         "CREATE VIEW adbc_table_types_view_test AS ( "
+                                         "SELECT * FROM adbc_table_types_table_test)",
+                                         &error),
+                IsOkStatus(&error));
+    int64_t rows_affected = 0;
+    ASSERT_THAT(
+        AdbcStatementExecuteQuery(&statement.value, nullptr, &rows_affected, &error),
+        IsOkStatus(&error));
+  }
+
+  adbc_validation::StreamReader reader;
+  std::vector<const char*> table_types = {"view", nullptr};
+  ASSERT_THAT(AdbcConnectionGetObjects(&connection, ADBC_OBJECT_DEPTH_ALL, nullptr,
+                                       nullptr, nullptr, table_types.data(), nullptr,
+                                       &reader.stream.value, &error),
+              IsOkStatus(&error));
+  ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+  ASSERT_NO_FATAL_FAILURE(reader.Next());
+  ASSERT_NE(nullptr, reader.array->release);
+  ASSERT_GT(reader.array->length, 0);
+
+  auto get_objects_data = adbc_validation::GetObjectsReader{&reader.array_view.value};
+  ASSERT_NE(*get_objects_data, nullptr)
+      << "could not initialize the AdbcGetInfoData object";
+
+  struct AdbcGetObjectsTable* table = AdbcGetObjectsDataGetTableByName(
+      *get_objects_data, "postgres", "public", "adbc_table_types_table_test");
+  ASSERT_EQ(table, nullptr) << "unexpected table adbc_table_types_table_test found";
+
+  struct AdbcGetObjectsTable* view = AdbcGetObjectsDataGetTableByName(
+      *get_objects_data, "postgres", "public", "adbc_table_types_view_test");
+  ASSERT_NE(view, nullptr) << "did not find view adbc_table_types_view_test";
+}
+
+TEST_F(PostgresConnectionTest, MetadataSetCurrentDbSchema) {
+  ASSERT_THAT(AdbcConnectionNew(&connection, &error), IsOkStatus(&error));
+  ASSERT_THAT(AdbcConnectionInit(&connection, &database, &error), IsOkStatus(&error));
+
+  {
+    adbc_validation::Handle<struct AdbcStatement> statement;
+    ASSERT_THAT(AdbcStatementNew(&connection, &statement.value, &error),
+                IsOkStatus(&error));
+
+    ASSERT_THAT(AdbcStatementSetSqlQuery(
+                    &statement.value, "CREATE SCHEMA IF NOT EXISTS testschema", &error),
+                IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement.value, nullptr, nullptr, &error),
+                IsOkStatus(&error));
+
+    ASSERT_THAT(
+        AdbcStatementSetSqlQuery(
+            &statement.value,
+            "CREATE TABLE IF NOT EXISTS testschema.schematable (ints INT)", &error),
+        IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement.value, nullptr, nullptr, &error),
+                IsOkStatus(&error));
+
+    ASSERT_THAT(AdbcStatementRelease(&statement.value, &error), IsOkStatus(&error));
+  }
+
+  adbc_validation::Handle<struct AdbcStatement> statement;
+  ASSERT_THAT(AdbcStatementNew(&connection, &statement.value, &error),
+              IsOkStatus(&error));
+
+  // Table does not exist in this schema
+  error.vendor_code = ADBC_ERROR_VENDOR_CODE_PRIVATE_DATA;
+  ASSERT_THAT(
+      AdbcStatementSetSqlQuery(&statement.value, "SELECT * FROM schematable", &error),
+      IsOkStatus(&error));
+  ASSERT_THAT(AdbcStatementExecuteQuery(&statement.value, nullptr, nullptr, &error),
+              IsStatus(ADBC_STATUS_NOT_FOUND, &error));
+  // 42P01 = table not found
+  ASSERT_EQ("42P01", std::string_view(error.sqlstate, 5));
+  ASSERT_NE(0, AdbcErrorGetDetailCount(&error));
+  bool found = false;
+  for (int i = 0; i < AdbcErrorGetDetailCount(&error); i++) {
+    struct AdbcErrorDetail detail = AdbcErrorGetDetail(&error, i);
+    if (std::strcmp(detail.key, "PG_DIAG_MESSAGE_PRIMARY") == 0) {
+      found = true;
+      std::string_view message(reinterpret_cast<const char*>(detail.value),
+                               detail.value_length);
+      ASSERT_THAT(message, ::testing::HasSubstr("schematable"));
+    }
+  }
+  error.release(&error);
+  ASSERT_TRUE(found) << "Did not find expected error detail";
+
+  ASSERT_THAT(
+      AdbcConnectionSetOption(&connection, ADBC_CONNECTION_OPTION_CURRENT_DB_SCHEMA,
+                              "testschema", &error),
+      IsOkStatus(&error));
+
+  ASSERT_THAT(
+      AdbcStatementSetSqlQuery(&statement.value, "SELECT * FROM schematable", &error),
+      IsOkStatus(&error));
+  ASSERT_THAT(AdbcStatementExecuteQuery(&statement.value, nullptr, nullptr, &error),
+              IsOkStatus(&error));
+
+  ASSERT_THAT(AdbcStatementRelease(&statement.value, &error), IsOkStatus(&error));
+}
+
+TEST_F(PostgresConnectionTest, MetadataGetStatistics) {
+  if (!quirks()->supports_statistics()) {
+    GTEST_SKIP();
+  }
+
+  ASSERT_THAT(AdbcConnectionNew(&connection, &error), IsOkStatus(&error));
+  ASSERT_THAT(AdbcConnectionInit(&connection, &database, &error), IsOkStatus(&error));
+
+  // Create sample table
+  {
+    adbc_validation::Handle<struct AdbcStatement> statement;
+    ASSERT_THAT(AdbcStatementNew(&connection, &statement.value, &error),
+                IsOkStatus(&error));
+
+    ASSERT_THAT(AdbcStatementSetSqlQuery(&statement.value,
+                                         "DROP TABLE IF EXISTS statstable", &error),
+                IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement.value, nullptr, nullptr, &error),
+                IsOkStatus(&error));
+
+    ASSERT_THAT(
+        AdbcStatementSetSqlQuery(&statement.value,
+                                 "CREATE TABLE statstable (ints INT, strs TEXT)", &error),
+        IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement.value, nullptr, nullptr, &error),
+                IsOkStatus(&error));
+
+    ASSERT_THAT(
+        AdbcStatementSetSqlQuery(
+            &statement.value,
+            "INSERT INTO statstable VALUES (1, 'a'), (NULL, 'bcd'), (-5, NULL)", &error),
+        IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement.value, nullptr, nullptr, &error),
+                IsOkStatus(&error));
+
+    ASSERT_THAT(AdbcStatementSetSqlQuery(&statement.value, "ANALYZE statstable", &error),
+                IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement.value, nullptr, nullptr, &error),
+                IsOkStatus(&error));
+
+    ASSERT_THAT(AdbcStatementRelease(&statement.value, &error), IsOkStatus(&error));
+  }
+
+  adbc_validation::StreamReader reader;
+  ASSERT_THAT(
+      AdbcConnectionGetStatistics(&connection, nullptr, quirks()->db_schema().c_str(),
+                                  "statstable", 1, &reader.stream.value, &error),
+      IsOkStatus(&error));
+  ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+
+  ASSERT_NO_FATAL_FAILURE(adbc_validation::CompareSchema(
+      &reader.schema.value, {
+                                {"catalog_name", NANOARROW_TYPE_STRING, true},
+                                {"catalog_db_schemas", NANOARROW_TYPE_LIST, false},
+                            }));
+
+  ASSERT_NO_FATAL_FAILURE(adbc_validation::CompareSchema(
+      reader.schema->children[1]->children[0],
+      {
+          {"db_schema_name", NANOARROW_TYPE_STRING, true},
+          {"db_schema_statistics", NANOARROW_TYPE_LIST, false},
+      }));
+
+  ASSERT_NO_FATAL_FAILURE(adbc_validation::CompareSchema(
+      reader.schema->children[1]->children[0]->children[1]->children[0],
+      {
+          {"table_name", NANOARROW_TYPE_STRING, false},
+          {"column_name", NANOARROW_TYPE_STRING, true},
+          {"statistic_key", NANOARROW_TYPE_INT16, false},
+          {"statistic_value", NANOARROW_TYPE_DENSE_UNION, false},
+          {"statistic_is_approximate", NANOARROW_TYPE_BOOL, false},
+      }));
+
+  ASSERT_NO_FATAL_FAILURE(adbc_validation::CompareSchema(
+      reader.schema->children[1]->children[0]->children[1]->children[0]->children[3],
+      {
+          {"int64", NANOARROW_TYPE_INT64, true},
+          {"uint64", NANOARROW_TYPE_UINT64, true},
+          {"float64", NANOARROW_TYPE_DOUBLE, true},
+          {"binary", NANOARROW_TYPE_BINARY, true},
+      }));
+
+  std::vector<std::tuple<std::optional<std::string>, int16_t, int64_t>> seen;
+  while (true) {
+    ASSERT_NO_FATAL_FAILURE(reader.Next());
+    if (!reader.array->release) break;
+
+    for (int64_t catalog_index = 0; catalog_index < reader.array->length;
+         catalog_index++) {
+      struct ArrowStringView catalog_name =
+          ArrowArrayViewGetStringUnsafe(reader.array_view->children[0], catalog_index);
+      ASSERT_EQ(quirks()->catalog(),
+                std::string_view(catalog_name.data,
+                                 static_cast<int64_t>(catalog_name.size_bytes)));
+
+      struct ArrowArrayView* catalog_db_schemas = reader.array_view->children[1];
+      struct ArrowArrayView* schema_stats = catalog_db_schemas->children[0]->children[1];
+      struct ArrowArrayView* stats =
+          catalog_db_schemas->children[0]->children[1]->children[0];
+      for (int64_t schema_index =
+               ArrowArrayViewListChildOffset(catalog_db_schemas, catalog_index);
+           schema_index <
+           ArrowArrayViewListChildOffset(catalog_db_schemas, catalog_index + 1);
+           schema_index++) {
+        struct ArrowStringView schema_name = ArrowArrayViewGetStringUnsafe(
+            catalog_db_schemas->children[0]->children[0], schema_index);
+        ASSERT_EQ(quirks()->db_schema(),
+                  std::string_view(schema_name.data,
+                                   static_cast<int64_t>(schema_name.size_bytes)));
+
+        for (int64_t stat_index =
+                 ArrowArrayViewListChildOffset(schema_stats, schema_index);
+             stat_index < ArrowArrayViewListChildOffset(schema_stats, schema_index + 1);
+             stat_index++) {
+          struct ArrowStringView table_name =
+              ArrowArrayViewGetStringUnsafe(stats->children[0], stat_index);
+          ASSERT_EQ("statstable",
+                    std::string_view(table_name.data,
+                                     static_cast<int64_t>(table_name.size_bytes)));
+          std::optional<std::string> column_name;
+          if (!ArrowArrayViewIsNull(stats->children[1], stat_index)) {
+            struct ArrowStringView value =
+                ArrowArrayViewGetStringUnsafe(stats->children[1], stat_index);
+            column_name = std::string(value.data, value.size_bytes);
+          }
+          ASSERT_TRUE(ArrowArrayViewGetIntUnsafe(stats->children[4], stat_index));
+
+          const int16_t stat_key = static_cast<int16_t>(
+              ArrowArrayViewGetIntUnsafe(stats->children[2], stat_index));
+          const int32_t offset =
+              stats->children[3]->buffer_views[1].data.as_int32[stat_index];
+          int64_t stat_value;
+          switch (stat_key) {
+            case ADBC_STATISTIC_AVERAGE_BYTE_WIDTH_KEY:
+            case ADBC_STATISTIC_DISTINCT_COUNT_KEY:
+            case ADBC_STATISTIC_NULL_COUNT_KEY:
+            case ADBC_STATISTIC_ROW_COUNT_KEY:
+              stat_value = static_cast<int64_t>(
+                  std::round(100 * ArrowArrayViewGetDoubleUnsafe(
+                                       stats->children[3]->children[2], offset)));
+              break;
+            default:
+              continue;
+          }
+          seen.emplace_back(std::move(column_name), stat_key, stat_value);
+        }
+      }
+    }
+  }
+
+  ASSERT_THAT(seen,
+              ::testing::UnorderedElementsAreArray(
+                  std::vector<std::tuple<std::optional<std::string>, int16_t, int64_t>>{
+                      {"ints", ADBC_STATISTIC_AVERAGE_BYTE_WIDTH_KEY, 400},
+                      {"strs", ADBC_STATISTIC_AVERAGE_BYTE_WIDTH_KEY, 300},
+                      {"ints", ADBC_STATISTIC_NULL_COUNT_KEY, 100},
+                      {"strs", ADBC_STATISTIC_NULL_COUNT_KEY, 100},
+                      {"ints", ADBC_STATISTIC_DISTINCT_COUNT_KEY, 200},
+                      {"strs", ADBC_STATISTIC_DISTINCT_COUNT_KEY, 200},
+                      {std::nullopt, ADBC_STATISTIC_ROW_COUNT_KEY, 300},
+                  }));
+}
+
+ADBCV_TEST_CONNECTION(PostgresConnectionTest)
+
+class PostgresStatementTest : public ::testing::Test,
+                              public adbc_validation::StatementTest {
+ public:
+  const adbc_validation::DriverQuirks* quirks() const override { return &quirks_; }
+  void SetUp() override { ASSERT_NO_FATAL_FAILURE(SetUpTest()); }
+  void TearDown() override { ASSERT_NO_FATAL_FAILURE(TearDownTest()); }
+
+  void TestSqlIngestUInt8() { GTEST_SKIP() << "Not implemented"; }
+  void TestSqlIngestUInt16() { GTEST_SKIP() << "Not implemented"; }
+  void TestSqlIngestUInt32() { GTEST_SKIP() << "Not implemented"; }
+  void TestSqlIngestUInt64() { GTEST_SKIP() << "Not implemented"; }
+
+  void TestSqlPrepareErrorParamCountMismatch() { GTEST_SKIP() << "Not yet implemented"; }
+  void TestSqlPrepareGetParameterSchema() { GTEST_SKIP() << "Not yet implemented"; }
+  void TestSqlPrepareSelectParams() { GTEST_SKIP() << "Not yet implemented"; }
+
+  void TestConcurrentStatements() {
+    // TODO: refactor driver so that we read all the data as soon as
+    // we ExecuteQuery() since that's how libpq already works - then
+    // we can actually support concurrent statements (because there is
+    // no concurrency)
+    GTEST_SKIP() << "Not yet implemented";
+  }
+
+ protected:
+  void ValidateIngestedTemporalData(struct ArrowArrayView* values, ArrowType type,
+                                    enum ArrowTimeUnit unit,
+                                    const char* timezone) override {
+    switch (type) {
+      case NANOARROW_TYPE_TIMESTAMP: {
+        std::vector<std::optional<int64_t>> expected;
+        switch (unit) {
+          case (NANOARROW_TIME_UNIT_SECOND):
+            expected.insert(expected.end(), {std::nullopt, -42000000, 0, 42000000});
+            break;
+          case (NANOARROW_TIME_UNIT_MILLI):
+            expected.insert(expected.end(), {std::nullopt, -42000, 0, 42000});
+            break;
+          case (NANOARROW_TIME_UNIT_MICRO):
+            expected.insert(expected.end(), {std::nullopt, -42, 0, 42});
+            break;
+          case (NANOARROW_TIME_UNIT_NANO):
+            expected.insert(expected.end(), {std::nullopt, 0, 0, 0});
+            break;
+        }
+        ASSERT_NO_FATAL_FAILURE(
+            adbc_validation::CompareArray<std::int64_t>(values, expected));
+        break;
+      }
+      case NANOARROW_TYPE_DURATION: {
+        struct ArrowInterval neg_interval;
+        struct ArrowInterval zero_interval;
+        struct ArrowInterval pos_interval;
+
+        ArrowIntervalInit(&neg_interval, type);
+        ArrowIntervalInit(&zero_interval, type);
+        ArrowIntervalInit(&pos_interval, type);
+
+        neg_interval.months = 0;
+        neg_interval.days = 0;
+        zero_interval.months = 0;
+        zero_interval.days = 0;
+        pos_interval.months = 0;
+        pos_interval.days = 0;
+
+        switch (unit) {
+          case (NANOARROW_TIME_UNIT_SECOND):
+            neg_interval.ns = -42000000000;
+            zero_interval.ns = 0;
+            pos_interval.ns = 42000000000;
+            break;
+          case (NANOARROW_TIME_UNIT_MILLI):
+            neg_interval.ns = -42000000;
+            zero_interval.ns = 0;
+            pos_interval.ns = 42000000;
+            break;
+          case (NANOARROW_TIME_UNIT_MICRO):
+            neg_interval.ns = -42000;
+            zero_interval.ns = 0;
+            pos_interval.ns = 42000;
+            break;
+          case (NANOARROW_TIME_UNIT_NANO):
+            // lower than us precision is lost
+            neg_interval.ns = 0;
+            zero_interval.ns = 0;
+            pos_interval.ns = 0;
+            break;
+        }
+        const std::vector<std::optional<ArrowInterval*>> expected = {
+            std::nullopt, &neg_interval, &zero_interval, &pos_interval};
+        ASSERT_NO_FATAL_FAILURE(
+            adbc_validation::CompareArray<ArrowInterval*>(values, expected));
+        break;
+      }
+      default:
+        FAIL() << "ValidateIngestedTemporalData not implemented for type " << type;
+    }
+  }
+
+  PostgresQuirks quirks_;
+};
+ADBCV_TEST_STATEMENT(PostgresStatementTest)
+
+TEST_F(PostgresStatementTest, SqlIngestSchema) {
+  const std::string schema_name = "testschema";
+
+  ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
+
+  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement,
+                                       "CREATE SCHEMA IF NOT EXISTS testschema", &error),
+              IsOkStatus(&error));
+  ASSERT_THAT(AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error),
+              IsOkStatus(&error));
+
+  std::string drop = "DROP TABLE IF EXISTS testschema.schematable";
+  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, drop.c_str(), &error),
+              IsOkStatus(&error));
+  ASSERT_THAT(AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error),
+              IsOkStatus(&error));
+
+  {
+    adbc_validation::Handle<struct ArrowSchema> schema;
+    adbc_validation::Handle<struct ArrowArray> batch;
+
+    ArrowSchemaInit(&schema.value);
+    ASSERT_THAT(ArrowSchemaSetTypeStruct(&schema.value, 1), adbc_validation::IsOkErrno());
+    ASSERT_THAT(ArrowSchemaSetType(schema->children[0], NANOARROW_TYPE_INT64),
+                adbc_validation::IsOkErrno());
+    ASSERT_THAT(ArrowSchemaSetName(schema->children[0], "ints"),
+                adbc_validation::IsOkErrno());
+
+    ASSERT_THAT((adbc_validation::MakeBatch<int64_t>(
+                    &schema.value, &batch.value, static_cast<struct ArrowError*>(nullptr),
+                    {-1, 0, 1, std::nullopt})),
+                adbc_validation::IsOkErrno());
+
+    ASSERT_THAT(AdbcStatementSetOption(&statement, ADBC_INGEST_OPTION_TARGET_TABLE,
+                                       "schematable", &error),
+                IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementSetOption(&statement, ADBC_INGEST_OPTION_MODE,
+                                       ADBC_INGEST_OPTION_MODE_CREATE, &error),
+                IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementSetOption(&statement, ADBC_INGEST_OPTION_TARGET_DB_SCHEMA,
+                                       schema_name.c_str(), &error),
+                IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementBind(&statement, &batch.value, &schema.value, &error),
+                IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error),
+                IsOkStatus(&error));
+  }
+}
+
+TEST_F(PostgresStatementTest, SqlIngestTemporaryTable) {
+  ASSERT_THAT(quirks()->DropTempTable(&connection, "temptable", &error),
+              IsOkStatus(&error));
+
+  ASSERT_THAT(AdbcConnectionSetOption(&connection, ADBC_CONNECTION_OPTION_AUTOCOMMIT,
+                                      ADBC_OPTION_VALUE_DISABLED, &error),
+              IsOkStatus(&error));
+
+  ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
+
+  ASSERT_THAT(AdbcStatementSetSqlQuery(
+                  &statement, "CREATE TEMPORARY TABLE temptable (ints BIGINT)", &error),
+              IsOkStatus(&error));
+  ASSERT_THAT(AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error),
+              IsOkStatus(&error));
+
+  ASSERT_THAT(AdbcConnectionCommit(&connection, &error), IsOkStatus(&error));
+
+  {
+    adbc_validation::Handle<struct ArrowSchema> schema;
+    adbc_validation::Handle<struct ArrowArray> batch;
+
+    ArrowSchemaInit(&schema.value);
+    ASSERT_THAT(ArrowSchemaSetTypeStruct(&schema.value, 1), adbc_validation::IsOkErrno());
+    ASSERT_THAT(ArrowSchemaSetType(schema->children[0], NANOARROW_TYPE_INT64),
+                adbc_validation::IsOkErrno());
+    ASSERT_THAT(ArrowSchemaSetName(schema->children[0], "ints"),
+                adbc_validation::IsOkErrno());
+
+    ASSERT_THAT((adbc_validation::MakeBatch<int64_t>(
+                    &schema.value, &batch.value, static_cast<struct ArrowError*>(nullptr),
+                    {-1, 0, 1, std::nullopt})),
+                adbc_validation::IsOkErrno());
+
+    ASSERT_THAT(AdbcStatementSetOption(&statement, ADBC_INGEST_OPTION_TARGET_TABLE,
+                                       "temptable", &error),
+                IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementSetOption(&statement, ADBC_INGEST_OPTION_MODE,
+                                       ADBC_INGEST_OPTION_MODE_APPEND, &error),
+                IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementBind(&statement, &batch.value, &schema.value, &error),
+                IsOkStatus(&error));
+    // because temporary table
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error),
+                IsStatus(ADBC_STATUS_NOT_FOUND, &error));
+  }
+
+  ASSERT_THAT(AdbcConnectionRollback(&connection, &error), IsOkStatus(&error));
+
+  {
+    adbc_validation::Handle<struct ArrowSchema> schema;
+    adbc_validation::Handle<struct ArrowArray> batch;
+
+    ArrowSchemaInit(&schema.value);
+    ASSERT_THAT(ArrowSchemaSetTypeStruct(&schema.value, 1), adbc_validation::IsOkErrno());
+    ASSERT_THAT(ArrowSchemaSetType(schema->children[0], NANOARROW_TYPE_INT64),
+                adbc_validation::IsOkErrno());
+    ASSERT_THAT(ArrowSchemaSetName(schema->children[0], "ints"),
+                adbc_validation::IsOkErrno());
+
+    ASSERT_THAT((adbc_validation::MakeBatch<int64_t>(
+                    &schema.value, &batch.value, static_cast<struct ArrowError*>(nullptr),
+                    {-1, 0, 1, std::nullopt})),
+                adbc_validation::IsOkErrno());
+
+    ASSERT_THAT(AdbcStatementSetOption(&statement, ADBC_INGEST_OPTION_TARGET_TABLE,
+                                       "temptable", &error),
+                IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementSetOption(&statement, ADBC_INGEST_OPTION_MODE,
+                                       ADBC_INGEST_OPTION_MODE_APPEND, &error),
+                IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementBind(&statement, &batch.value, &schema.value, &error),
+                IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementSetOption(&statement, ADBC_INGEST_OPTION_TEMPORARY,
+                                       ADBC_OPTION_VALUE_ENABLED, &error),
+                IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error),
+                IsOkStatus(&error));
+  }
+}
+
+TEST_F(PostgresStatementTest, SqlIngestTimestampOverflow) {
+  ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
+
+  {
+    adbc_validation::Handle<struct ArrowSchema> schema;
+    adbc_validation::Handle<struct ArrowArray> batch;
+
+    ArrowSchemaInit(&schema.value);
+    ASSERT_THAT(ArrowSchemaSetTypeStruct(&schema.value, 1), adbc_validation::IsOkErrno());
+    ASSERT_THAT(ArrowSchemaSetName(schema->children[0], "$1"),
+                adbc_validation::IsOkErrno());
+    ASSERT_THAT(ArrowSchemaSetTypeDateTime(schema->children[0], NANOARROW_TYPE_TIMESTAMP,
+                                           NANOARROW_TIME_UNIT_SECOND, nullptr),
+                adbc_validation::IsOkErrno());
+
+    ASSERT_THAT((adbc_validation::MakeBatch<int64_t>(
+                    &schema.value, &batch.value, static_cast<struct ArrowError*>(nullptr),
+                    {std::numeric_limits<int64_t>::max()})),
+                adbc_validation::IsOkErrno());
+
+    ASSERT_THAT(
+        AdbcStatementSetSqlQuery(&statement, "SELECT CAST($1 AS TIMESTAMP)", &error),
+        IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementBind(&statement, &batch.value, &schema.value, &error),
+                IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementPrepare(&statement, &error), IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error),
+                IsStatus(ADBC_STATUS_INVALID_ARGUMENT, &error));
+    ASSERT_THAT(error.message,
+                ::testing::HasSubstr("Row #1 has value '9223372036854775807' which "
+                                     "exceeds PostgreSQL timestamp limits"));
+  }
+
+  {
+    adbc_validation::Handle<struct ArrowSchema> schema;
+    adbc_validation::Handle<struct ArrowArray> batch;
+
+    ArrowSchemaInit(&schema.value);
+    ASSERT_THAT(ArrowSchemaSetTypeStruct(&schema.value, 1), adbc_validation::IsOkErrno());
+    ASSERT_THAT(ArrowSchemaSetName(schema->children[0], "$1"),
+                adbc_validation::IsOkErrno());
+    ASSERT_THAT(ArrowSchemaSetTypeDateTime(schema->children[0], NANOARROW_TYPE_TIMESTAMP,
+                                           NANOARROW_TIME_UNIT_SECOND, nullptr),
+                adbc_validation::IsOkErrno());
+
+    ASSERT_THAT((adbc_validation::MakeBatch<int64_t>(
+                    &schema.value, &batch.value, static_cast<struct ArrowError*>(nullptr),
+                    {std::numeric_limits<int64_t>::min()})),
+                adbc_validation::IsOkErrno());
+
+    ASSERT_THAT(
+        AdbcStatementSetSqlQuery(&statement, "SELECT CAST($1 AS TIMESTAMP)", &error),
+        IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementBind(&statement, &batch.value, &schema.value, &error),
+                IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementPrepare(&statement, &error), IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error),
+                IsStatus(ADBC_STATUS_INVALID_ARGUMENT, &error));
+    ASSERT_THAT(error.message,
+                ::testing::HasSubstr("Row #1 has value '-9223372036854775808' which "
+                                     "exceeds PostgreSQL timestamp limits"));
+  }
+}
+
+TEST_F(PostgresStatementTest, SqlReadIntervalOverflow) {
+  ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
+
+  {
+    ASSERT_THAT(
+        AdbcStatementSetSqlQuery(
+            &statement, "SELECT CAST('P0Y0M0DT2562048H0M0S' AS INTERVAL)", &error),
+        IsOkStatus(&error));
+    adbc_validation::StreamReader reader;
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                          &reader.rows_affected, &error),
+                IsOkStatus(&error));
+    ASSERT_EQ(reader.rows_affected, -1);
+    ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+    ASSERT_THAT(reader.MaybeNext(),
+                adbc_validation::IsErrno(EINVAL, &reader.stream.value, nullptr));
+    ASSERT_THAT(reader.stream->get_last_error(&reader.stream.value),
+                ::testing::HasSubstr("Interval with time value 9223372800000000 usec "
+                                     "would overflow when converting to nanoseconds"));
+    ASSERT_EQ(reader.array->release, nullptr);
+  }
+
+  {
+    ASSERT_THAT(
+        AdbcStatementSetSqlQuery(
+            &statement, "SELECT CAST('P0Y0M0DT-2562048H0M0S' AS INTERVAL)", &error),
+        IsOkStatus(&error));
+    adbc_validation::StreamReader reader;
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                          &reader.rows_affected, &error),
+                IsOkStatus(&error));
+    ASSERT_EQ(reader.rows_affected, -1);
+    ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+    ASSERT_THAT(reader.MaybeNext(),
+                adbc_validation::IsErrno(EINVAL, &reader.stream.value, nullptr));
+    ASSERT_THAT(reader.stream->get_last_error(&reader.stream.value),
+                ::testing::HasSubstr("Interval with time value -9223372800000000 usec "
+                                     "would overflow when converting to nanoseconds"));
+    ASSERT_EQ(reader.array->release, nullptr);
+  }
+}
+
+TEST_F(PostgresStatementTest, UpdateInExecuteQuery) {
+  ASSERT_THAT(quirks()->DropTable(&connection, "adbc_test", &error), IsOkStatus(&error));
+
+  ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
+
+  {
+    ASSERT_THAT(AdbcStatementSetSqlQuery(
+                    &statement,
+                    "CREATE TABLE adbc_test (ints INT, id SERIAL PRIMARY KEY)", &error),
+                IsOkStatus(&error));
+    adbc_validation::StreamReader reader;
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                          &reader.rows_affected, &error),
+                IsOkStatus(&error));
+    ASSERT_EQ(reader.rows_affected, -1);
+    ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+    ASSERT_NO_FATAL_FAILURE(reader.Next());
+    ASSERT_EQ(reader.array->release, nullptr);
+  }
+
+  {
+    // Use INSERT INTO
+    ASSERT_THAT(AdbcStatementSetSqlQuery(
+                    &statement, "INSERT INTO adbc_test (ints) VALUES (1), (2)", &error),
+                IsOkStatus(&error));
+    adbc_validation::StreamReader reader;
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                          &reader.rows_affected, &error),
+                IsOkStatus(&error));
+    ASSERT_EQ(reader.rows_affected, -1);
+    ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+    ASSERT_NO_FATAL_FAILURE(reader.Next());
+    ASSERT_EQ(reader.array->release, nullptr);
+  }
+
+  {
+    // Use INSERT INTO ... RETURNING
+    ASSERT_THAT(AdbcStatementSetSqlQuery(
+                    &statement,
+                    "INSERT INTO adbc_test (ints) VALUES (3), (4) RETURNING id", &error),
+                IsOkStatus(&error));
+    adbc_validation::StreamReader reader;
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                          &reader.rows_affected, &error),
+                IsOkStatus(&error));
+    ASSERT_EQ(reader.rows_affected, -1);
+    ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+    ASSERT_NO_FATAL_FAILURE(reader.Next());
+    ASSERT_NE(reader.array->release, nullptr);
+    ASSERT_EQ(reader.array->n_children, 1);
+    ASSERT_EQ(reader.array->length, 2);
+    ASSERT_EQ(reader.array_view->children[0]->buffer_views[1].data.as_int32[0], 3);
+    ASSERT_EQ(reader.array_view->children[0]->buffer_views[1].data.as_int32[1], 4);
+    ASSERT_NO_FATAL_FAILURE(reader.Next());
+    ASSERT_EQ(reader.array->release, nullptr);
+  }
+}
+
+TEST_F(PostgresStatementTest, BatchSizeHint) {
+  ASSERT_THAT(quirks()->EnsureSampleTable(&connection, "batch_size_hint_test", &error),
+              IsOkStatus(&error));
+  ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
+
+  // Setting the batch size hint to a negative or non-integer value should fail
+  ASSERT_EQ(AdbcStatementSetOption(&statement, "adbc.postgresql.batch_size_hint_bytes",
+                                   "-1", nullptr),
+            ADBC_STATUS_INVALID_ARGUMENT);
+  ASSERT_EQ(AdbcStatementSetOption(&statement, "adbc.postgresql.batch_size_hint_bytes",
+                                   "not a valid number", nullptr),
+            ADBC_STATUS_INVALID_ARGUMENT);
+
+  // For this test, use a batch size of 1 byte to force every row to be its own batch
+  ASSERT_THAT(AdbcStatementSetOption(&statement, "adbc.postgresql.batch_size_hint_bytes",
+                                     "1", &error),
+              IsOkStatus(&error));
+
+  {
+    ASSERT_THAT(
+        AdbcStatementSetSqlQuery(
+            &statement, "SELECT int64s from batch_size_hint_test ORDER BY int64s LIMIT 3",
+            &error),
+        IsOkStatus(&error));
+
+    adbc_validation::StreamReader reader;
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                          &reader.rows_affected, &error),
+                IsOkStatus(&error));
+    ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+    ASSERT_NO_FATAL_FAILURE(reader.Next());
+    ASSERT_EQ(reader.array->length, 1);
+    ASSERT_EQ(ArrowArrayViewGetIntUnsafe(reader.array_view->children[0], 0), -42);
+    ASSERT_NO_FATAL_FAILURE(reader.Next());
+    ASSERT_EQ(reader.array->length, 1);
+    ASSERT_EQ(ArrowArrayViewGetIntUnsafe(reader.array_view->children[0], 0), 42);
+    ASSERT_NO_FATAL_FAILURE(reader.Next());
+    ASSERT_EQ(reader.array->length, 1);
+    ASSERT_TRUE(ArrowArrayViewIsNull(reader.array_view->children[0], 0));
+    ASSERT_NO_FATAL_FAILURE(reader.Next());
+    ASSERT_EQ(reader.array->release, nullptr);
+  }
+}
+
+// Test that an ADBC 1.0.0-sized error still works
+TEST_F(PostgresStatementTest, AdbcErrorBackwardsCompatibility) {
+  // XXX: sketchy cast
+  auto* error = static_cast<struct AdbcError*>(malloc(ADBC_ERROR_1_0_0_SIZE));
+  std::memset(error, 0, ADBC_ERROR_1_0_0_SIZE);
+
+  ASSERT_THAT(AdbcStatementNew(&connection, &statement, error), IsOkStatus(error));
+  ASSERT_THAT(
+      AdbcStatementSetSqlQuery(&statement, "SELECT * FROM thistabledoesnotexist", error),
+      IsOkStatus(error));
+  adbc_validation::StreamReader reader;
+  ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                        &reader.rows_affected, error),
+              IsStatus(ADBC_STATUS_NOT_FOUND, error));
+
+  ASSERT_EQ("42P01", std::string_view(error->sqlstate, 5));
+  ASSERT_EQ(0, AdbcErrorGetDetailCount(error));
+
+  error->release(error);
+  free(error);
+}
+
+TEST_F(PostgresStatementTest, Cancel) {
+  ASSERT_THAT(AdbcStatementNew(&connection, &statement, &error), IsOkStatus(&error));
+
+  for (const char* query : {
+           "DROP TABLE IF EXISTS test_cancel",
+           "CREATE TABLE test_cancel (ints INT)",
+           R"(INSERT INTO test_cancel (ints)
+              SELECT g :: INT FROM GENERATE_SERIES(1, 65536) temp(g))",
+       }) {
+    ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, query, &error), IsOkStatus(&error));
+    ASSERT_THAT(AdbcStatementExecuteQuery(&statement, nullptr, nullptr, &error),
+                IsOkStatus(&error));
+  }
+
+  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement, "SELECT * FROM test_cancel", &error),
+              IsOkStatus(&error));
+  adbc_validation::StreamReader reader;
+  ASSERT_THAT(AdbcStatementExecuteQuery(&statement, &reader.stream.value,
+                                        &reader.rows_affected, &error),
+              IsOkStatus(&error));
+
+  ASSERT_THAT(AdbcStatementCancel(&statement, &error), IsOkStatus(&error));
+
+  int retcode = 0;
+  while (true) {
+    retcode = reader.MaybeNext();
+    if (retcode != 0 || !reader.array->release) break;
+  }
+
+  ASSERT_EQ(ECANCELED, retcode);
+  AdbcStatusCode status = ADBC_STATUS_OK;
+  const struct AdbcError* detail =
+      AdbcErrorFromArrayStream(&reader.stream.value, &status);
+  ASSERT_NE(nullptr, detail);
+  ASSERT_EQ(ADBC_STATUS_CANCELLED, status);
+  ASSERT_EQ("57014", std::string_view(detail->sqlstate, 5));
+  ASSERT_NE(0, AdbcErrorGetDetailCount(detail));
+}
+
+struct TypeTestCase {
+  std::string name;
+  std::string sql_type;
+  std::string sql_literal;
+  ArrowType arrow_type;
+  std::variant<bool, int64_t, double, std::string> scalar;
+
+  static std::string FormatName(const ::testing::TestParamInfo<TypeTestCase>& info) {
+    return info.param.name;
+  }
+};
+
+void PrintTo(const TypeTestCase& value, std::ostream* os) { (*os) << value.name; }
+
+class PostgresTypeTest : public ::testing::TestWithParam<TypeTestCase> {
+ public:
+  void SetUp() override {
+    ASSERT_THAT(AdbcDatabaseNew(&database_, &error_), IsOkStatus(&error_));
+    ASSERT_THAT(quirks_.SetupDatabase(&database_, &error_), IsOkStatus(&error_));
+    ASSERT_THAT(AdbcDatabaseInit(&database_, &error_), IsOkStatus(&error_));
+
+    ASSERT_THAT(AdbcConnectionNew(&connection_, &error_), IsOkStatus(&error_));
+    ASSERT_THAT(AdbcConnectionInit(&connection_, &database_, &error_),
+                IsOkStatus(&error_));
+
+    ASSERT_THAT(AdbcStatementNew(&connection_, &statement_, &error_),
+                IsOkStatus(&error_));
+
+    ASSERT_THAT(quirks_.DropTable(&connection_, "foo", &error_), IsOkStatus(&error_));
+  }
+  void TearDown() override {
+    if (statement_.private_data) {
+      ASSERT_THAT(AdbcStatementRelease(&statement_, &error_), IsOkStatus(&error_));
+    }
+    if (connection_.private_data) {
+      ASSERT_THAT(AdbcConnectionRelease(&connection_, &error_), IsOkStatus(&error_));
+    }
+    if (database_.private_data) {
+      ASSERT_THAT(AdbcDatabaseRelease(&database_, &error_), IsOkStatus(&error_));
+    }
+
+    if (error_.release) error_.release(&error_);
+  }
+
+ protected:
+  PostgresQuirks quirks_;
+  struct AdbcError error_ = {};
+  struct AdbcDatabase database_ = {};
+  struct AdbcConnection connection_ = {};
+  struct AdbcStatement statement_ = {};
+};
+
+TEST_P(PostgresTypeTest, SelectValue) {
+  std::string value = GetParam().sql_literal;
+  if ((value == "'-inf'") || (value == "'inf'")) {
+    const std::string version = adbc_validation::GetDriverVendorVersion(&connection_);
+    if (version < "140000") {
+      GTEST_SKIP() << "-inf and inf not implemented until postgres 14";
+    }
+  }
+  // create table
+  std::string query = "CREATE TABLE foo (col ";
+  query += GetParam().sql_type;
+  query += ")";
+  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement_, query.c_str(), &error_),
+              IsOkStatus(&error_));
+  ASSERT_THAT(AdbcStatementExecuteQuery(&statement_, /*out=*/nullptr,
+                                        /*rows_affected=*/nullptr, &error_),
+              IsOkStatus(&error_));
+
+  // insert value
+  query = "INSERT INTO foo(col) VALUES ( ";
+  query += GetParam().sql_literal;
+  query += ")";
+  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement_, query.c_str(), &error_),
+              IsOkStatus(&error_));
+  ASSERT_THAT(AdbcStatementExecuteQuery(&statement_, /*out=*/nullptr,
+                                        /*rows_affected=*/nullptr, &error_),
+              IsOkStatus(&error_));
+
+  // select
+  adbc_validation::StreamReader reader;
+  query = "SELECT * FROM foo";
+  ASSERT_THAT(AdbcStatementSetSqlQuery(&statement_, query.c_str(), &error_),
+              IsOkStatus(&error_));
+  ASSERT_THAT(AdbcStatementExecuteQuery(&statement_, &reader.stream.value,
+                                        /*rows_affected=*/nullptr, &error_),
+              IsOkStatus(&error_));
+
+  // check type
+  ASSERT_NO_FATAL_FAILURE(reader.GetSchema());
+  ASSERT_NO_FATAL_FAILURE(adbc_validation::CompareSchema(
+      &reader.schema.value, {{std::nullopt, GetParam().arrow_type, true}}));
+  if (GetParam().arrow_type == NANOARROW_TYPE_TIMESTAMP) {
+    if (GetParam().sql_type.find("WITH TIME ZONE") == std::string::npos) {
+      ASSERT_STREQ(reader.schema->children[0]->format, "tsu:");
+    } else {
+      ASSERT_STREQ(reader.schema->children[0]->format, "tsu:UTC");
+    }
+  }
+
+  ASSERT_NO_FATAL_FAILURE(reader.Next());
+  ASSERT_NE(nullptr, reader.array->release);
+  ASSERT_FALSE(ArrowArrayViewIsNull(&reader.array_view.value, 0));
+  ASSERT_FALSE(ArrowArrayViewIsNull(reader.array_view->children[0], 0));
+
+  // check value
+  ASSERT_NO_FATAL_FAILURE(std::visit(
+      [&](auto&& arg) -> void {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, bool>) {
+          ASSERT_EQ(static_cast<int64_t>(arg),
+                    ArrowArrayViewGetIntUnsafe(reader.array_view->children[0], 0));
+        } else if constexpr (std::is_same_v<T, int64_t>) {
+          ASSERT_EQ(arg, ArrowArrayViewGetIntUnsafe(reader.array_view->children[0], 0));
+        } else if constexpr (std::is_same_v<T, double>) {
+          ASSERT_EQ(arg,
+                    ArrowArrayViewGetDoubleUnsafe(reader.array_view->children[0], 0));
+        } else if constexpr (std::is_same_v<T, std::string>) {
+          ArrowStringView view =
+              ArrowArrayViewGetStringUnsafe(reader.array_view->children[0], 0);
+          ASSERT_EQ(arg.size(), view.size_bytes);
+          ASSERT_EQ(0, std::strncmp(arg.c_str(), view.data, arg.size()));
+        } else {
+          FAIL() << "Unimplemented case";
+        }
+      },
+      GetParam().scalar));
+
+  ASSERT_NO_FATAL_FAILURE(reader.Next());
+  ASSERT_EQ(nullptr, reader.array->release);
+}
+
+static std::initializer_list<TypeTestCase> kBoolTypeCases = {
+    {"BOOL_TRUE", "BOOLEAN", "TRUE", NANOARROW_TYPE_BOOL, true},
+    {"BOOL_FALSE", "BOOLEAN", "FALSE", NANOARROW_TYPE_BOOL, false},
+};
+static std::initializer_list<TypeTestCase> kBinaryTypeCases = {
+    {"BYTEA", "BYTEA", R"('\000\001\002\003\004\005\006\007'::bytea)",
+     NANOARROW_TYPE_BINARY, std::string("\x00\x01\x02\x03\x04\x05\x06\x07", 8)},
+    {"TEXT", "TEXT", "'foobar'", NANOARROW_TYPE_STRING, "foobar"},
+    {"CHAR6_1", "CHAR(6)", "'foo'", NANOARROW_TYPE_STRING, "foo   "},
+    {"CHAR6_2", "CHAR(6)", "'foobar'", NANOARROW_TYPE_STRING, "foobar"},
+    {"VARCHAR", "VARCHAR", "'foobar'", NANOARROW_TYPE_STRING, "foobar"},
+};
+static std::initializer_list<TypeTestCase> kFloatTypeCases = {
+    {"REAL", "REAL", "-1E0", NANOARROW_TYPE_FLOAT, -1.0},
+    {"DOUBLE_PRECISION", "DOUBLE PRECISION", "-1E0", NANOARROW_TYPE_DOUBLE, -1.0},
+};
+static std::initializer_list<TypeTestCase> kIntTypeCases = {
+    {"SMALLINT", "SMALLINT", std::to_string(std::numeric_limits<int16_t>::min()),
+     NANOARROW_TYPE_INT16, static_cast<int64_t>(std::numeric_limits<int16_t>::min())},
+    {"INT", "INT", std::to_string(std::numeric_limits<int32_t>::min()),
+     NANOARROW_TYPE_INT32, static_cast<int64_t>(std::numeric_limits<int32_t>::min())},
+    {"BIGINT", "BIGINT", std::to_string(std::numeric_limits<int64_t>::min()),
+     NANOARROW_TYPE_INT64, std::numeric_limits<int64_t>::min()},
+    {"SERIAL", "SERIAL", std::to_string(std::numeric_limits<int32_t>::max()),
+     NANOARROW_TYPE_INT32, static_cast<int64_t>(std::numeric_limits<int32_t>::max())},
+    {"BIGSERIAL", "BIGSERIAL", std::to_string(std::numeric_limits<int64_t>::max()),
+     NANOARROW_TYPE_INT64, std::numeric_limits<int64_t>::max()},
+};
+static std::initializer_list<TypeTestCase> kNumericTypeCases = {
+    {"NUMERIC_TRAILING0", "NUMERIC", "1000000", NANOARROW_TYPE_STRING, "1000000"},
+    {"NUMERIC_LEADING0", "NUMERIC", "0.00001234", NANOARROW_TYPE_STRING, "0.00001234"},
+    {"NUMERIC_TRAILING02", "NUMERIC", "'1.0000'", NANOARROW_TYPE_STRING, "1.0000"},
+    {"NUMERIC_NEGATIVE", "NUMERIC", "-123.456", NANOARROW_TYPE_STRING, "-123.456"},
+    {"NUMERIC_POSITIVE", "NUMERIC", "123.456", NANOARROW_TYPE_STRING, "123.456"},
+    {"NUMERIC_NAN", "NUMERIC", "'nan'", NANOARROW_TYPE_STRING, "nan"},
+    {"NUMERIC_NINF", "NUMERIC", "'-inf'", NANOARROW_TYPE_STRING, "-inf"},
+    {"NUMERIC_PINF", "NUMERIC", "'inf'", NANOARROW_TYPE_STRING, "inf"},
+};
+static std::initializer_list<TypeTestCase> kDateTypeCases = {
+    {"DATE0", "DATE", "'1970-01-01'", NANOARROW_TYPE_DATE32, int64_t(0)},
+    {"DATE1", "DATE", "'2000-01-01'", NANOARROW_TYPE_DATE32, int64_t(10957)},
+    {"DATE2", "DATE", "'1950-01-01'", NANOARROW_TYPE_DATE32, int64_t(-7305)},
+};
+static std::initializer_list<TypeTestCase> kTimeTypeCases = {
+    {"TIME_WITHOUT_TIME_ZONE", "TIME WITHOUT TIME ZONE", "'00:00'", NANOARROW_TYPE_TIME64,
+     int64_t(0)},
+    {"TIME_WITHOUT_TIME_ZONE_VAL", "TIME WITHOUT TIME ZONE", "'01:02:03.123123'",
+     NANOARROW_TYPE_TIME64, int64_t(3'723'123'123)},
+    {"TIME_6_WITHOUT_TIME_ZONE", "TIME (6) WITHOUT TIME ZONE", "'00:00'",
+     NANOARROW_TYPE_TIME64, int64_t(0)},
+    {"TIME_6_WITHOUT_TIME_ZONE_VAL", "TIME (6) WITHOUT TIME ZONE", "'01:02:03.123123'",
+     NANOARROW_TYPE_TIME64, int64_t(3'723'123'123)},
+    {"TIME_5_WITHOUT_TIME_ZONE", "TIME (5) WITHOUT TIME ZONE", "'00:00'",
+     NANOARROW_TYPE_TIME64, int64_t(0)},
+    {"TIME_5_WITHOUT_TIME_ZONE_VAL", "TIME (5) WITHOUT TIME ZONE", "'01:02:03.123123'",
+     NANOARROW_TYPE_TIME64, int64_t(3'723'123'120)},
+    {"TIME_4_WITHOUT_TIME_ZONE", "TIME (4) WITHOUT TIME ZONE", "'00:00'",
+     NANOARROW_TYPE_TIME64, int64_t(0)},
+    {"TIME_4_WITHOUT_TIME_ZONE_VAL", "TIME (4) WITHOUT TIME ZONE", "'01:02:03.123123'",
+     NANOARROW_TYPE_TIME64, int64_t(3'723'123'100)},
+    {"TIME_3_WITHOUT_TIME_ZONE", "TIME (3) WITHOUT TIME ZONE", "'00:00'",
+     NANOARROW_TYPE_TIME64, int64_t(0)},
+    {"TIME_3_WITHOUT_TIME_ZONE_VAL", "TIME (3) WITHOUT TIME ZONE", "'01:02:03.123123'",
+     NANOARROW_TYPE_TIME64, int64_t(3'723'123'000)},
+    {"TIME_2_WITHOUT_TIME_ZONE", "TIME (2) WITHOUT TIME ZONE", "'00:00'",
+     NANOARROW_TYPE_TIME64, int64_t(0)},
+    {"TIME_2_WITHOUT_TIME_ZONE_VAL", "TIME (2) WITHOUT TIME ZONE", "'01:02:03.123123'",
+     NANOARROW_TYPE_TIME64, int64_t(3'723'120'000)},
+    {"TIME_1_WITHOUT_TIME_ZONE", "TIME (1) WITHOUT TIME ZONE", "'00:00'",
+     NANOARROW_TYPE_TIME64, int64_t(0)},
+    {"TIME_1_WITHOUT_TIME_ZONE_VAL", "TIME (1) WITHOUT TIME ZONE", "'01:02:03.123123'",
+     NANOARROW_TYPE_TIME64, int64_t(3'723'100'000)},
+    {"TIME_0_WITHOUT_TIME_ZONE", "TIME (0) WITHOUT TIME ZONE", "'00:00'",
+     NANOARROW_TYPE_TIME64, int64_t(0)},
+    {"TIME_0_WITHOUT_TIME_ZONE_VAL", "TIME (0) WITHOUT TIME ZONE", "'01:02:03.123123'",
+     NANOARROW_TYPE_TIME64, int64_t(3'723'000'000)},
+};
+static std::initializer_list<TypeTestCase> kTimestampTypeCases = {
+    {"TIMESTAMP_WITHOUT_TIME_ZONE", "TIMESTAMP WITHOUT TIME ZONE",
+     "'1970-01-01 00:00:00.000000'", NANOARROW_TYPE_TIMESTAMP, int64_t(0)},
+    {"TIMESTAMP_WITHOUT_TIME_ZONE_VAL", "TIMESTAMP WITHOUT TIME ZONE",
+     "'1970-01-02 03:04:05.123123'", NANOARROW_TYPE_TIMESTAMP, int64_t(97'445'123'123)},
+    {"TIMESTAMP_6_WITHOUT_TIME_ZONE", "TIMESTAMP (6) WITHOUT TIME ZONE",
+     "'1970-01-01 00:00:00.000000'", NANOARROW_TYPE_TIMESTAMP, int64_t(0)},
+    {"TIMESTAMP_6_WITHOUT_TIME_ZONE_VAL", "TIMESTAMP (6) WITHOUT TIME ZONE",
+     "'1970-01-02 03:04:05.123123'", NANOARROW_TYPE_TIMESTAMP, int64_t(97'445'123'123)},
+    {"TIMESTAMP_5_WITHOUT_TIME_ZONE", "TIMESTAMP (5) WITHOUT TIME ZONE",
+     "'1970-01-01 00:00:00.000000'", NANOARROW_TYPE_TIMESTAMP, int64_t(0)},
+    {"TIMESTAMP_5_WITHOUT_TIME_ZONE_VAL", "TIMESTAMP (5) WITHOUT TIME ZONE",
+     "'1970-01-02 03:04:05.123123'", NANOARROW_TYPE_TIMESTAMP, int64_t(97'445'123'120)},
+    {"TIMESTAMP_4_WITHOUT_TIME_ZONE", "TIMESTAMP (4) WITHOUT TIME ZONE",
+     "'1970-01-01 00:00:00.000000'", NANOARROW_TYPE_TIMESTAMP, int64_t(0)},
+    {"TIMESTAMP_4_WITHOUT_TIME_ZONE_VAL", "TIMESTAMP (4) WITHOUT TIME ZONE",
+     "'1970-01-02 03:04:05.123123'", NANOARROW_TYPE_TIMESTAMP, int64_t(97'445'123'100)},
+    {"TIMESTAMP_3_WITHOUT_TIME_ZONE", "TIMESTAMP (3) WITHOUT TIME ZONE",
+     "'1970-01-01 00:00:00.000000'", NANOARROW_TYPE_TIMESTAMP, int64_t(0)},
+    {"TIMESTAMP_3_WITHOUT_TIME_ZONE_VAL", "TIMESTAMP (3) WITHOUT TIME ZONE",
+     "'1970-01-02 03:04:05.123123'", NANOARROW_TYPE_TIMESTAMP, int64_t(97'445'123'000)},
+    {"TIMESTAMP_2_WITHOUT_TIME_ZONE", "TIMESTAMP (2) WITHOUT TIME ZONE",
+     "'1970-01-01 00:00:00.000000'", NANOARROW_TYPE_TIMESTAMP, int64_t(0)},
+    {"TIMESTAMP_2_WITHOUT_TIME_ZONE_VAL", "TIMESTAMP (2) WITHOUT TIME ZONE",
+     "'1970-01-02 03:04:05.123123'", NANOARROW_TYPE_TIMESTAMP, int64_t(97'445'120'000)},
+    {"TIMESTAMP_1_WITHOUT_TIME_ZONE", "TIMESTAMP (1) WITHOUT TIME ZONE",
+     "'1970-01-01 00:00:00.000000'", NANOARROW_TYPE_TIMESTAMP, int64_t(0)},
+    {"TIMESTAMP_1_WITHOUT_TIME_ZONE_VAL", "TIMESTAMP (1) WITHOUT TIME ZONE",
+     "'1970-01-02 03:04:05.123123'", NANOARROW_TYPE_TIMESTAMP, int64_t(97'445'100'000)},
+    {"TIMESTAMP_0_WITHOUT_TIME_ZONE", "TIMESTAMP (0) WITHOUT TIME ZONE",
+     "'1970-01-01 00:00:00.000000'", NANOARROW_TYPE_TIMESTAMP, int64_t(0)},
+    {"TIMESTAMP_0_WITHOUT_TIME_ZONE_VAL", "TIMESTAMP (0) WITHOUT TIME ZONE",
+     "'1970-01-02 03:04:05.123123'", NANOARROW_TYPE_TIMESTAMP, int64_t(97'445'000'000)},
+    {"TIMESTAMP_WITH_TIME_ZONE", "TIMESTAMP WITH TIME ZONE",
+     "'1970-01-01 00:00:00.000000+00:30'", NANOARROW_TYPE_TIMESTAMP,
+     int64_t(-1'800'000'000)},
+    {"TIMESTAMP_WITH_TIME_ZONE_VAL", "TIMESTAMP WITH TIME ZONE",
+     "'1970-01-02 03:04:05.123123+00:30'", NANOARROW_TYPE_TIMESTAMP,
+     int64_t(95'645'123'123)},
+    {"TIMESTAMP_6_WITH_TIME_ZONE", "TIMESTAMP (6) WITH TIME ZONE",
+     "'1970-01-01 00:00:00.000000+00:30'", NANOARROW_TYPE_TIMESTAMP,
+     int64_t(-1'800'000'000)},
+    {"TIMESTAMP_6_WITH_TIME_ZONE_VAL", "TIMESTAMP (6) WITH TIME ZONE",
+     "'1970-01-02 03:04:05.123123+00:30'", NANOARROW_TYPE_TIMESTAMP,
+     int64_t(95'645'123'123)},
+    {"TIMESTAMP_5_WITH_TIME_ZONE", "TIMESTAMP (5) WITH TIME ZONE",
+     "'1970-01-01 00:00:00.000000+00:30'", NANOARROW_TYPE_TIMESTAMP,
+     int64_t(-1'800'000'000)},
+    {"TIMESTAMP_5_WITH_TIME_ZONE_VAL", "TIMESTAMP (5) WITH TIME ZONE",
+     "'1970-01-02 03:04:05.123123+00:30'", NANOARROW_TYPE_TIMESTAMP,
+     int64_t(95'645'123'120)},
+    {"TIMESTAMP_4_WITH_TIME_ZONE", "TIMESTAMP (4) WITH TIME ZONE",
+     "'1970-01-01 00:00:00.000000+00:30'", NANOARROW_TYPE_TIMESTAMP,
+     int64_t(-1'800'000'000)},
+    {"TIMESTAMP_4_WITH_TIME_ZONE_VAL", "TIMESTAMP (4) WITH TIME ZONE",
+     "'1970-01-02 03:04:05.123123+00:30'", NANOARROW_TYPE_TIMESTAMP,
+     int64_t(95'645'123'100)},
+    {"TIMESTAMP_3_WITH_TIME_ZONE", "TIMESTAMP (3) WITH TIME ZONE",
+     "'1970-01-01 00:00:00.000000+00:30'", NANOARROW_TYPE_TIMESTAMP,
+     int64_t(-1'800'000'000)},
+    {"TIMESTAMP_3_WITH_TIME_ZONE_VAL", "TIMESTAMP (3) WITH TIME ZONE",
+     "'1970-01-02 03:04:05.123123+00:30'", NANOARROW_TYPE_TIMESTAMP,
+     int64_t(95'645'123'000)},
+    {"TIMESTAMP_2_WITH_TIME_ZONE", "TIMESTAMP (2) WITH TIME ZONE",
+     "'1970-01-01 00:00:00.000000+00:30'", NANOARROW_TYPE_TIMESTAMP,
+     int64_t(-1'800'000'000)},
+    {"TIMESTAMP_2_WITH_TIME_ZONE_VAL", "TIMESTAMP (2) WITH TIME ZONE",
+     "'1970-01-02 03:04:05.123123+00:30'", NANOARROW_TYPE_TIMESTAMP,
+     int64_t(95'645'120'000)},
+    {"TIMESTAMP_1_WITH_TIME_ZONE", "TIMESTAMP (1) WITH TIME ZONE",
+     "'1970-01-01 00:00:00.000000+00:30'", NANOARROW_TYPE_TIMESTAMP,
+     int64_t(-1'800'000'000)},
+    {"TIMESTAMP_1_WITH_TIME_ZONE_VAL", "TIMESTAMP (1) WITH TIME ZONE",
+     "'1970-01-02 03:04:05.123123+00:30'", NANOARROW_TYPE_TIMESTAMP,
+     int64_t(95'645'100'000)},
+    {"TIMESTAMP_0_WITH_TIME_ZONE", "TIMESTAMP (0) WITH TIME ZONE",
+     "'1970-01-01 00:00:00.000000+00:30'", NANOARROW_TYPE_TIMESTAMP,
+     int64_t(-1'800'000'000)},
+    {"TIMESTAMP_0_WITH_TIME_ZONE_VAL", "TIMESTAMP (0) WITH TIME ZONE",
+     "'1970-01-02 03:04:05.123123+00:30'", NANOARROW_TYPE_TIMESTAMP,
+     int64_t(95'645'000'000)},
+};
+
+INSTANTIATE_TEST_SUITE_P(BoolType, PostgresTypeTest, testing::ValuesIn(kBoolTypeCases),
+                         TypeTestCase::FormatName);
+INSTANTIATE_TEST_SUITE_P(BinaryTypes, PostgresTypeTest,
+                         testing::ValuesIn(kBinaryTypeCases), TypeTestCase::FormatName);
+INSTANTIATE_TEST_SUITE_P(FloatTypes, PostgresTypeTest, testing::ValuesIn(kFloatTypeCases),
+                         TypeTestCase::FormatName);
+INSTANTIATE_TEST_SUITE_P(IntTypes, PostgresTypeTest, testing::ValuesIn(kIntTypeCases),
+                         TypeTestCase::FormatName);
+INSTANTIATE_TEST_SUITE_P(NumericType, PostgresTypeTest,
+                         testing::ValuesIn(kNumericTypeCases), TypeTestCase::FormatName);
+INSTANTIATE_TEST_SUITE_P(DateTypes, PostgresTypeTest, testing::ValuesIn(kDateTypeCases),
+                         TypeTestCase::FormatName);
+INSTANTIATE_TEST_SUITE_P(TimeTypes, PostgresTypeTest, testing::ValuesIn(kTimeTypeCases),
+                         TypeTestCase::FormatName);
+INSTANTIATE_TEST_SUITE_P(TimestampTypes, PostgresTypeTest,
+                         testing::ValuesIn(kTimestampTypeCases),
+                         TypeTestCase::FormatName);

--- a/c/driver/netezza/result_helper.cc
+++ b/c/driver/netezza/result_helper.cc
@@ -1,0 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "result_helper.h"
+
+#include "common/utils.h"
+#include "error.h"
+
+namespace adbcpq {
+
+PqResultHelper::~PqResultHelper() {
+  if (result_ != nullptr) {
+    PQclear(result_);
+  }
+}
+
+AdbcStatusCode PqResultHelper::Prepare() {
+  // TODO: make stmtName a unique identifier?
+  PGresult* result =
+      PQprepare(conn_, /*stmtName=*/"", query_.c_str(), param_values_.size(), NULL);
+  if (PQresultStatus(result) != PGRES_COMMAND_OK) {
+    AdbcStatusCode code =
+        SetError(error_, result, "[libpq] Failed to prepare query: %s\nQuery was:%s",
+                 PQerrorMessage(conn_), query_.c_str());
+    PQclear(result);
+    return code;
+  }
+
+  PQclear(result);
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PqResultHelper::Execute() {
+  std::vector<const char*> param_c_strs;
+
+  for (size_t index = 0; index < param_values_.size(); index++) {
+    param_c_strs.push_back(param_values_[index].c_str());
+  }
+
+  result_ =
+      PQexecPrepared(conn_, "", param_values_.size(), param_c_strs.data(), NULL, NULL, 0);
+
+  ExecStatusType status = PQresultStatus(result_);
+  if (status != PGRES_TUPLES_OK && status != PGRES_COMMAND_OK) {
+    AdbcStatusCode error =
+        SetError(error_, result_, "[libpq] Failed to execute query '%s': %s",
+                 query_.c_str(), PQerrorMessage(conn_));
+    return error;
+  }
+
+  return ADBC_STATUS_OK;
+}
+
+}  // namespace adbcpq

--- a/c/driver/netezza/result_helper.h
+++ b/c/driver/netezza/result_helper.h
@@ -1,0 +1,133 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cassert>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <adbc.h>
+#include <libpq-fe.h>
+
+namespace adbcpq {
+
+/// \brief A single column in a single row of a result set.
+struct PqRecord {
+  const char* data;
+  const int len;
+  const bool is_null;
+
+  // XXX: can't use optional due to R
+  std::pair<bool, double> ParseDouble() const {
+    char* end;
+    double result = std::strtod(data, &end);
+    if (errno != 0 || end == data) {
+      return std::make_pair(false, 0.0);
+    }
+    return std::make_pair(true, result);
+  }
+};
+
+// Used by PqResultHelper to provide index-based access to the records within each
+// row of a PGresult
+class PqResultRow {
+ public:
+  PqResultRow(PGresult* result, int row_num) : result_(result), row_num_(row_num) {
+    ncols_ = PQnfields(result);
+  }
+
+  PqRecord operator[](const int& col_num) {
+    assert(col_num < ncols_);
+    const char* data = PQgetvalue(result_, row_num_, col_num);
+    const int len = PQgetlength(result_, row_num_, col_num);
+    const bool is_null = PQgetisnull(result_, row_num_, col_num);
+
+    return PqRecord{data, len, is_null};
+  }
+
+ private:
+  PGresult* result_ = nullptr;
+  int row_num_;
+  int ncols_;
+};
+
+// Helper to manager the lifecycle of a PQResult. The query argument
+// will be evaluated as part of the constructor, with the desctructor handling cleanup
+// Caller must call Prepare then Execute, checking both for an OK AdbcStatusCode
+// prior to iterating
+class PqResultHelper {
+ public:
+  explicit PqResultHelper(PGconn* conn, std::string query, struct AdbcError* error)
+      : conn_(conn), query_(std::move(query)), error_(error) {}
+
+  explicit PqResultHelper(PGconn* conn, std::string query,
+                          std::vector<std::string> param_values, struct AdbcError* error)
+      : conn_(conn),
+        query_(std::move(query)),
+        param_values_(std::move(param_values)),
+        error_(error) {}
+
+  ~PqResultHelper();
+
+  AdbcStatusCode Prepare();
+  AdbcStatusCode Execute();
+
+  int NumRows() const { return PQntuples(result_); }
+
+  int NumColumns() const { return PQnfields(result_); }
+
+  class iterator {
+    const PqResultHelper& outer_;
+    int curr_row_ = 0;
+
+   public:
+    explicit iterator(const PqResultHelper& outer, int curr_row = 0)
+        : outer_(outer), curr_row_(curr_row) {}
+    iterator& operator++() {
+      curr_row_++;
+      return *this;
+    }
+    iterator operator++(int) {
+      iterator retval = *this;
+      ++(*this);
+      return retval;
+    }
+    bool operator==(iterator other) const {
+      return outer_.result_ == other.outer_.result_ && curr_row_ == other.curr_row_;
+    }
+    bool operator!=(iterator other) const { return !(*this == other); }
+    PqResultRow operator*() { return PqResultRow(outer_.result_, curr_row_); }
+    using iterator_category = std::forward_iterator_tag;
+    using difference_type = std::ptrdiff_t;
+    using value_type = std::vector<PqResultRow>;
+    using pointer = const std::vector<PqResultRow>*;
+    using reference = const std::vector<PqResultRow>&;
+  };
+
+  iterator begin() { return iterator(*this); }
+  iterator end() { return iterator(*this, NumRows()); }
+
+ private:
+  PGresult* result_ = nullptr;
+  PGconn* conn_;
+  std::string query_;
+  std::vector<std::string> param_values_;
+  struct AdbcError* error_;
+};
+}  // namespace adbcpq

--- a/c/driver/netezza/statement.cc
+++ b/c/driver/netezza/statement.cc
@@ -1,0 +1,1557 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Windows
+#define NOMINMAX
+
+#include "statement.h"
+
+#include <array>
+#include <cassert>
+#include <cerrno>
+#include <cinttypes>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <adbc.h>
+#include <libpq-fe.h>
+#include <nanoarrow/nanoarrow.hpp>
+
+#include "common/options.h"
+#include "common/utils.h"
+#include "connection.h"
+#include "error.h"
+#include "postgres_copy_reader.h"
+#include "postgres_type.h"
+#include "postgres_util.h"
+#include "result_helper.h"
+
+namespace adbcpq {
+
+namespace {
+/// The flag indicating to PostgreSQL that we want binary-format values.
+constexpr int kPgBinaryFormat = 1;
+
+/// One-value ArrowArrayStream used to unify the implementations of Bind
+struct OneValueStream {
+  struct ArrowSchema schema;
+  struct ArrowArray array;
+
+  static int GetSchema(struct ArrowArrayStream* self, struct ArrowSchema* out) {
+    OneValueStream* stream = static_cast<OneValueStream*>(self->private_data);
+    return ArrowSchemaDeepCopy(&stream->schema, out);
+  }
+  static int GetNext(struct ArrowArrayStream* self, struct ArrowArray* out) {
+    OneValueStream* stream = static_cast<OneValueStream*>(self->private_data);
+    *out = stream->array;
+    stream->array.release = nullptr;
+    return 0;
+  }
+  static const char* GetLastError(struct ArrowArrayStream* self) { return NULL; }
+  static void Release(struct ArrowArrayStream* self) {
+    OneValueStream* stream = static_cast<OneValueStream*>(self->private_data);
+    if (stream->schema.release) {
+      stream->schema.release(&stream->schema);
+      stream->schema.release = nullptr;
+    }
+    if (stream->array.release) {
+      stream->array.release(&stream->array);
+      stream->array.release = nullptr;
+    }
+    delete stream;
+    self->release = nullptr;
+  }
+};
+
+/// Build an PostgresType object from a PGresult*
+AdbcStatusCode ResolvePostgresType(const PostgresTypeResolver& type_resolver,
+                                   PGresult* result, PostgresType* out,
+                                   struct AdbcError* error) {
+  ArrowError na_error;
+  const int num_fields = PQnfields(result);
+  PostgresType root_type(PostgresTypeId::kRecord);
+
+  for (int i = 0; i < num_fields; i++) {
+    const Oid pg_oid = PQftype(result, i);
+    PostgresType pg_type;
+    if (type_resolver.Find(pg_oid, &pg_type, &na_error) != NANOARROW_OK) {
+      SetError(error, "%s%d%s%s%s%d", "[libpq] Column #", i + 1, " (\"",
+               PQfname(result, i), "\") has unknown type code ", pg_oid);
+      return ADBC_STATUS_NOT_IMPLEMENTED;
+    }
+
+    root_type.AppendChild(PQfname(result, i), pg_type);
+  }
+
+  *out = root_type;
+  return ADBC_STATUS_OK;
+}
+
+/// Helper to manage bind parameters with a prepared statement
+struct BindStream {
+  Handle<struct ArrowArrayStream> bind;
+  Handle<struct ArrowSchema> bind_schema;
+  struct ArrowSchemaView bind_schema_view;
+  std::vector<struct ArrowSchemaView> bind_schema_fields;
+
+  // OIDs for parameter types
+  std::vector<uint32_t> param_types;
+  std::vector<char*> param_values;
+  std::vector<int> param_lengths;
+  std::vector<int> param_formats;
+  std::vector<size_t> param_values_offsets;
+  std::vector<char> param_values_buffer;
+  // XXX: this assumes fixed-length fields only - will need more
+  // consideration to deal with variable-length fields
+
+  bool has_tz_field = false;
+  std::string tz_setting;
+
+  struct ArrowError na_error;
+
+  explicit BindStream(struct ArrowArrayStream&& bind) {
+    this->bind.value = std::move(bind);
+    std::memset(&na_error, 0, sizeof(na_error));
+  }
+
+  template <typename Callback>
+  AdbcStatusCode Begin(Callback&& callback, struct AdbcError* error) {
+    CHECK_NA(INTERNAL, bind->get_schema(&bind.value, &bind_schema.value), error);
+    CHECK_NA(
+        INTERNAL,
+        ArrowSchemaViewInit(&bind_schema_view, &bind_schema.value, /*error*/ nullptr),
+        error);
+
+    if (bind_schema_view.type != ArrowType::NANOARROW_TYPE_STRUCT) {
+      SetError(error, "%s", "[libpq] Bind parameters must have type STRUCT");
+      return ADBC_STATUS_INVALID_STATE;
+    }
+
+    bind_schema_fields.resize(bind_schema->n_children);
+    for (size_t i = 0; i < bind_schema_fields.size(); i++) {
+      CHECK_NA(INTERNAL,
+               ArrowSchemaViewInit(&bind_schema_fields[i], bind_schema->children[i],
+                                   /*error*/ nullptr),
+               error);
+    }
+
+    return std::move(callback)();
+  }
+
+  AdbcStatusCode SetParamTypes(const PostgresTypeResolver& type_resolver,
+                               struct AdbcError* error) {
+    param_types.resize(bind_schema->n_children);
+    param_values.resize(bind_schema->n_children);
+    param_lengths.resize(bind_schema->n_children);
+    param_formats.resize(bind_schema->n_children, kPgBinaryFormat);
+    param_values_offsets.reserve(bind_schema->n_children);
+
+    for (size_t i = 0; i < bind_schema_fields.size(); i++) {
+      PostgresTypeId type_id;
+      switch (bind_schema_fields[i].type) {
+        case ArrowType::NANOARROW_TYPE_BOOL:
+          type_id = PostgresTypeId::kBool;
+          param_lengths[i] = 1;
+          break;
+        case ArrowType::NANOARROW_TYPE_INT8:
+        case ArrowType::NANOARROW_TYPE_INT16:
+          type_id = PostgresTypeId::kInt2;
+          param_lengths[i] = 2;
+          break;
+        case ArrowType::NANOARROW_TYPE_INT32:
+          type_id = PostgresTypeId::kInt4;
+          param_lengths[i] = 4;
+          break;
+        case ArrowType::NANOARROW_TYPE_INT64:
+          type_id = PostgresTypeId::kInt8;
+          param_lengths[i] = 8;
+          break;
+        case ArrowType::NANOARROW_TYPE_FLOAT:
+          type_id = PostgresTypeId::kFloat4;
+          param_lengths[i] = 4;
+          break;
+        case ArrowType::NANOARROW_TYPE_DOUBLE:
+          type_id = PostgresTypeId::kFloat8;
+          param_lengths[i] = 8;
+          break;
+        case ArrowType::NANOARROW_TYPE_STRING:
+        case ArrowType::NANOARROW_TYPE_LARGE_STRING:
+          type_id = PostgresTypeId::kText;
+          param_lengths[i] = 0;
+          break;
+        case ArrowType::NANOARROW_TYPE_BINARY:
+          type_id = PostgresTypeId::kBytea;
+          param_lengths[i] = 0;
+          break;
+        case ArrowType::NANOARROW_TYPE_DATE32:
+          type_id = PostgresTypeId::kDate;
+          param_lengths[i] = 4;
+          break;
+        case ArrowType::NANOARROW_TYPE_TIMESTAMP:
+          type_id = PostgresTypeId::kTimestamp;
+          param_lengths[i] = 8;
+          break;
+        case ArrowType::NANOARROW_TYPE_DURATION:
+        case ArrowType::NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO:
+          type_id = PostgresTypeId::kInterval;
+          param_lengths[i] = 16;
+          break;
+        case ArrowType::NANOARROW_TYPE_DICTIONARY: {
+          struct ArrowSchemaView value_view;
+          CHECK_NA(INTERNAL,
+                   ArrowSchemaViewInit(&value_view, bind_schema->children[i]->dictionary,
+                                       nullptr),
+                   error);
+          switch (value_view.type) {
+            case NANOARROW_TYPE_BINARY:
+            case NANOARROW_TYPE_LARGE_BINARY:
+              type_id = PostgresTypeId::kBytea;
+              param_lengths[i] = 0;
+              break;
+            case NANOARROW_TYPE_STRING:
+            case NANOARROW_TYPE_LARGE_STRING:
+              type_id = PostgresTypeId::kText;
+              param_lengths[i] = 0;
+              break;
+            default:
+              SetError(error, "%s%" PRIu64 "%s%s%s%s", "[libpq] Field #",
+                       static_cast<uint64_t>(i + 1), " ('",
+                       bind_schema->children[i]->name,
+                       "') has unsupported dictionary value parameter type ",
+                       ArrowTypeString(value_view.type));
+              return ADBC_STATUS_NOT_IMPLEMENTED;
+          }
+          break;
+        }
+        default:
+          SetError(error, "%s%" PRIu64 "%s%s%s%s", "[libpq] Field #",
+                   static_cast<uint64_t>(i + 1), " ('", bind_schema->children[i]->name,
+                   "') has unsupported parameter type ",
+                   ArrowTypeString(bind_schema_fields[i].type));
+          return ADBC_STATUS_NOT_IMPLEMENTED;
+      }
+
+      param_types[i] = type_resolver.GetOID(type_id);
+      if (param_types[i] == 0) {
+        SetError(error, "%s%" PRIu64 "%s%s%s%s", "[libpq] Field #",
+                 static_cast<uint64_t>(i + 1), " ('", bind_schema->children[i]->name,
+                 "') has type with no corresponding PostgreSQL type ",
+                 ArrowTypeString(bind_schema_fields[i].type));
+        return ADBC_STATUS_NOT_IMPLEMENTED;
+      }
+    }
+
+    size_t param_values_length = 0;
+    for (int length : param_lengths) {
+      param_values_offsets.push_back(param_values_length);
+      param_values_length += length;
+    }
+    param_values_buffer.resize(param_values_length);
+    return ADBC_STATUS_OK;
+  }
+
+  AdbcStatusCode Prepare(PGconn* conn, const std::string& query, struct AdbcError* error,
+                         const bool autocommit) {
+    // tz-aware timestamps require special handling to set the timezone to UTC
+    // prior to sending over the binary protocol; must be reset after execute
+    for (int64_t col = 0; col < bind_schema->n_children; col++) {
+      if ((bind_schema_fields[col].type == ArrowType::NANOARROW_TYPE_TIMESTAMP) &&
+          (strcmp("", bind_schema_fields[col].timezone))) {
+        has_tz_field = true;
+
+        if (autocommit) {
+          PGresult* begin_result = PQexec(conn, "BEGIN");
+          if (PQresultStatus(begin_result) != PGRES_COMMAND_OK) {
+            AdbcStatusCode code =
+                SetError(error, begin_result,
+                         "[libpq] Failed to begin transaction for timezone data: %s",
+                         PQerrorMessage(conn));
+            PQclear(begin_result);
+            return code;
+          }
+          PQclear(begin_result);
+        }
+
+        PGresult* get_tz_result = PQexec(conn, "SELECT current_setting('TIMEZONE')");
+        if (PQresultStatus(get_tz_result) != PGRES_TUPLES_OK) {
+          AdbcStatusCode code = SetError(error, get_tz_result,
+                                         "[libpq] Could not query current timezone: %s",
+                                         PQerrorMessage(conn));
+          PQclear(get_tz_result);
+          return code;
+        }
+
+        tz_setting = std::string(PQgetvalue(get_tz_result, 0, 0));
+        PQclear(get_tz_result);
+
+        PGresult* set_utc_result = PQexec(conn, "SET TIME ZONE 'UTC'");
+        if (PQresultStatus(set_utc_result) != PGRES_COMMAND_OK) {
+          AdbcStatusCode code = SetError(error, set_utc_result,
+                                         "[libpq] Failed to set time zone to UTC: %s",
+                                         PQerrorMessage(conn));
+          PQclear(set_utc_result);
+          return code;
+        }
+        PQclear(set_utc_result);
+        break;
+      }
+    }
+
+    PGresult* result = PQprepare(conn, /*stmtName=*/"", query.c_str(),
+                                 /*nParams=*/bind_schema->n_children, param_types.data());
+    if (PQresultStatus(result) != PGRES_COMMAND_OK) {
+      AdbcStatusCode code =
+          SetError(error, result, "[libpq] Failed to prepare query: %s\nQuery was:%s",
+                   PQerrorMessage(conn), query.c_str());
+      PQclear(result);
+      return code;
+    }
+    PQclear(result);
+    return ADBC_STATUS_OK;
+  }
+
+  AdbcStatusCode Execute(PGconn* conn, int64_t* rows_affected, struct AdbcError* error) {
+    if (rows_affected) *rows_affected = 0;
+    PGresult* result = nullptr;
+
+    while (true) {
+      Handle<struct ArrowArray> array;
+      int res = bind->get_next(&bind.value, &array.value);
+      if (res != 0) {
+        SetError(error,
+                 "[libpq] Failed to read next batch from stream of bind parameters: "
+                 "(%d) %s %s",
+                 res, std::strerror(res), bind->get_last_error(&bind.value));
+        return ADBC_STATUS_IO;
+      }
+      if (!array->release) break;
+
+      Handle<struct ArrowArrayView> array_view;
+      // TODO: include error messages
+      CHECK_NA(
+          INTERNAL,
+          ArrowArrayViewInitFromSchema(&array_view.value, &bind_schema.value, nullptr),
+          error);
+      CHECK_NA(INTERNAL, ArrowArrayViewSetArray(&array_view.value, &array.value, nullptr),
+               error);
+
+      for (int64_t row = 0; row < array->length; row++) {
+        for (int64_t col = 0; col < array_view->n_children; col++) {
+          if (ArrowArrayViewIsNull(array_view->children[col], row)) {
+            param_values[col] = nullptr;
+            continue;
+          } else {
+            param_values[col] = param_values_buffer.data() + param_values_offsets[col];
+          }
+          switch (bind_schema_fields[col].type) {
+            case ArrowType::NANOARROW_TYPE_BOOL: {
+              const int8_t val = ArrowBitGet(
+                  array_view->children[col]->buffer_views[1].data.as_uint8, row);
+              std::memcpy(param_values[col], &val, sizeof(int8_t));
+              break;
+            }
+
+            case ArrowType::NANOARROW_TYPE_INT8: {
+              const int16_t val =
+                  array_view->children[col]->buffer_views[1].data.as_int8[row];
+              const uint16_t value = ToNetworkInt16(val);
+              std::memcpy(param_values[col], &value, sizeof(int16_t));
+              break;
+            }
+            case ArrowType::NANOARROW_TYPE_INT16: {
+              const uint16_t value = ToNetworkInt16(
+                  array_view->children[col]->buffer_views[1].data.as_int16[row]);
+              std::memcpy(param_values[col], &value, sizeof(int16_t));
+              break;
+            }
+            case ArrowType::NANOARROW_TYPE_INT32: {
+              const uint32_t value = ToNetworkInt32(
+                  array_view->children[col]->buffer_views[1].data.as_int32[row]);
+              std::memcpy(param_values[col], &value, sizeof(int32_t));
+              break;
+            }
+            case ArrowType::NANOARROW_TYPE_INT64: {
+              const int64_t value = ToNetworkInt64(
+                  array_view->children[col]->buffer_views[1].data.as_int64[row]);
+              std::memcpy(param_values[col], &value, sizeof(int64_t));
+              break;
+            }
+            case ArrowType::NANOARROW_TYPE_FLOAT: {
+              const uint32_t value = ToNetworkFloat4(
+                  array_view->children[col]->buffer_views[1].data.as_float[row]);
+              std::memcpy(param_values[col], &value, sizeof(uint32_t));
+              break;
+            }
+            case ArrowType::NANOARROW_TYPE_DOUBLE: {
+              const uint64_t value = ToNetworkFloat8(
+                  array_view->children[col]->buffer_views[1].data.as_double[row]);
+              std::memcpy(param_values[col], &value, sizeof(uint64_t));
+              break;
+            }
+            case ArrowType::NANOARROW_TYPE_STRING:
+            case ArrowType::NANOARROW_TYPE_LARGE_STRING:
+            case ArrowType::NANOARROW_TYPE_BINARY: {
+              const ArrowBufferView view =
+                  ArrowArrayViewGetBytesUnsafe(array_view->children[col], row);
+              // TODO: overflow check?
+              param_lengths[col] = static_cast<int>(view.size_bytes);
+              param_values[col] = const_cast<char*>(view.data.as_char);
+              break;
+            }
+            case ArrowType::NANOARROW_TYPE_DATE32: {
+              // 2000-01-01
+              constexpr int32_t kPostgresDateEpoch = 10957;
+              const int32_t raw_value =
+                  array_view->children[col]->buffer_views[1].data.as_int32[row];
+              if (raw_value < INT32_MIN + kPostgresDateEpoch) {
+                SetError(error, "[libpq] Field #%" PRId64 "%s%s%s%" PRId64 "%s", col + 1,
+                         "('", bind_schema->children[col]->name, "') Row #", row + 1,
+                         "has value which exceeds postgres date limits");
+                return ADBC_STATUS_INVALID_ARGUMENT;
+              }
+
+              const uint32_t value = ToNetworkInt32(raw_value - kPostgresDateEpoch);
+              std::memcpy(param_values[col], &value, sizeof(int32_t));
+              break;
+            }
+            case ArrowType::NANOARROW_TYPE_DURATION:
+            case ArrowType::NANOARROW_TYPE_TIMESTAMP: {
+              int64_t val = array_view->children[col]->buffer_views[1].data.as_int64[row];
+
+              bool overflow_safe = true;
+
+              auto unit = bind_schema_fields[col].time_unit;
+
+              switch (unit) {
+                case NANOARROW_TIME_UNIT_SECOND:
+                  if ((overflow_safe = val <= kMaxSafeSecondsToMicros &&
+                                       val >= kMinSafeSecondsToMicros)) {
+                    val *= 1000000;
+                  }
+
+                  break;
+                case NANOARROW_TIME_UNIT_MILLI:
+                  if ((overflow_safe = val <= kMaxSafeMillisToMicros &&
+                                       val >= kMinSafeMillisToMicros)) {
+                    val *= 1000;
+                  }
+                  break;
+                case NANOARROW_TIME_UNIT_MICRO:
+                  break;
+                case NANOARROW_TIME_UNIT_NANO:
+                  val /= 1000;
+                  break;
+              }
+
+              if (!overflow_safe) {
+                SetError(error,
+                         "[libpq] Field #%" PRId64 " ('%s') Row #%" PRId64
+                         " has value '%" PRIi64
+                         "' which exceeds PostgreSQL timestamp limits",
+                         col + 1, bind_schema->children[col]->name, row + 1,
+                         array_view->children[col]->buffer_views[1].data.as_int64[row]);
+                return ADBC_STATUS_INVALID_ARGUMENT;
+              }
+
+              if (val < std::numeric_limits<int64_t>::min() + kPostgresTimestampEpoch) {
+                SetError(error,
+                         "[libpq] Field #%" PRId64 " ('%s') Row #%" PRId64
+                         " has value '%" PRIi64 "' which would underflow",
+                         col + 1, bind_schema->children[col]->name, row + 1,
+                         array_view->children[col]->buffer_views[1].data.as_int64[row]);
+                return ADBC_STATUS_INVALID_ARGUMENT;
+              }
+
+              if (bind_schema_fields[col].type == ArrowType::NANOARROW_TYPE_TIMESTAMP) {
+                const uint64_t value = ToNetworkInt64(val - kPostgresTimestampEpoch);
+                std::memcpy(param_values[col], &value, sizeof(int64_t));
+              } else if (bind_schema_fields[col].type ==
+                         ArrowType::NANOARROW_TYPE_DURATION) {
+                // postgres stores an interval as a 64 bit offset in microsecond
+                // resolution alongside a 32 bit day and 32 bit month
+                // for now we just send 0 for the day / month values
+                const uint64_t value = ToNetworkInt64(val);
+                std::memcpy(param_values[col], &value, sizeof(int64_t));
+                std::memset(param_values[col] + sizeof(int64_t), 0, sizeof(int64_t));
+              }
+              break;
+            }
+            case ArrowType::NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO: {
+              struct ArrowInterval interval;
+              ArrowIntervalInit(&interval, NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO);
+              ArrowArrayViewGetIntervalUnsafe(array_view->children[col], row, &interval);
+
+              const uint32_t months = ToNetworkInt32(interval.months);
+              const uint32_t days = ToNetworkInt32(interval.days);
+              const uint64_t ms = ToNetworkInt64(interval.ns / 1000);
+
+              std::memcpy(param_values[col], &ms, sizeof(uint64_t));
+              std::memcpy(param_values[col] + sizeof(uint64_t), &days, sizeof(uint32_t));
+              std::memcpy(param_values[col] + sizeof(uint64_t) + sizeof(uint32_t),
+                          &months, sizeof(uint32_t));
+              break;
+            }
+            default:
+              SetError(error, "%s%" PRId64 "%s%s%s%s", "[libpq] Field #", col + 1, " ('",
+                       bind_schema->children[col]->name,
+                       "') has unsupported type for ingestion ",
+                       ArrowTypeString(bind_schema_fields[col].type));
+              return ADBC_STATUS_NOT_IMPLEMENTED;
+          }
+        }
+
+        result = PQexecPrepared(conn, /*stmtName=*/"",
+                                /*nParams=*/bind_schema->n_children, param_values.data(),
+                                param_lengths.data(), param_formats.data(),
+                                /*resultFormat=*/0 /*text*/);
+
+        ExecStatusType pg_status = PQresultStatus(result);
+        if (pg_status != PGRES_COMMAND_OK) {
+          AdbcStatusCode code = SetError(
+              error, result, "[libpq] Failed to execute prepared statement: %s %s",
+              PQresStatus(pg_status), PQerrorMessage(conn));
+          PQclear(result);
+          return code;
+        }
+
+        PQclear(result);
+      }
+      if (rows_affected) *rows_affected += array->length;
+
+      if (has_tz_field) {
+        std::string reset_query = "SET TIME ZONE '" + tz_setting + "'";
+        PGresult* reset_tz_result = PQexec(conn, reset_query.c_str());
+        if (PQresultStatus(reset_tz_result) != PGRES_COMMAND_OK) {
+          AdbcStatusCode code =
+              SetError(error, reset_tz_result, "[libpq] Failed to reset time zone: %s",
+                       PQerrorMessage(conn));
+          PQclear(reset_tz_result);
+          return code;
+        }
+        PQclear(reset_tz_result);
+
+        PGresult* commit_result = PQexec(conn, "COMMIT");
+        if (PQresultStatus(commit_result) != PGRES_COMMAND_OK) {
+          AdbcStatusCode code =
+              SetError(error, commit_result, "[libpq] Failed to commit transaction: %s",
+                       PQerrorMessage(conn));
+          PQclear(commit_result);
+          return code;
+        }
+        PQclear(commit_result);
+      }
+    }
+    return ADBC_STATUS_OK;
+  }
+
+  AdbcStatusCode ExecuteCopy(PGconn* conn, int64_t* rows_affected,
+                             struct AdbcError* error) {
+    if (rows_affected) *rows_affected = 0;
+
+    PostgresCopyStreamWriter writer;
+    CHECK_NA(INTERNAL, writer.Init(&bind_schema.value), error);
+    CHECK_NA(INTERNAL, writer.InitFieldWriters(nullptr), error);
+
+    CHECK_NA(INTERNAL, writer.WriteHeader(nullptr), error);
+
+    while (true) {
+      Handle<struct ArrowArray> array;
+      int res = bind->get_next(&bind.value, &array.value);
+      if (res != 0) {
+        SetError(error,
+                 "[libpq] Failed to read next batch from stream of bind parameters: "
+                 "(%d) %s %s",
+                 res, std::strerror(res), bind->get_last_error(&bind.value));
+        return ADBC_STATUS_IO;
+      }
+      if (!array->release) break;
+
+      CHECK_NA(INTERNAL, writer.SetArray(&array.value), error);
+
+      // build writer buffer
+      int write_result;
+      do {
+        write_result = writer.WriteRecord(nullptr);
+      } while (write_result == NANOARROW_OK);
+
+      // check if not ENODATA at exit
+      if (write_result != ENODATA) {
+        SetError(error, "Error occurred writing COPY data: %s", PQerrorMessage(conn));
+        return ADBC_STATUS_IO;
+      }
+
+      ArrowBuffer buffer = writer.WriteBuffer();
+      if (PQputCopyData(conn, reinterpret_cast<char*>(buffer.data), buffer.size_bytes) <=
+          0) {
+        SetError(error, "Error writing tuple field data: %s", PQerrorMessage(conn));
+        return ADBC_STATUS_IO;
+      }
+
+      if (rows_affected) *rows_affected += array->length;
+      writer.Rewind();
+    }
+
+    if (PQputCopyEnd(conn, NULL) <= 0) {
+      SetError(error, "Error message returned by PQputCopyEnd: %s", PQerrorMessage(conn));
+      return ADBC_STATUS_IO;
+    }
+
+    PGresult* result = PQgetResult(conn);
+    ExecStatusType pg_status = PQresultStatus(result);
+    if (pg_status != PGRES_COMMAND_OK) {
+      AdbcStatusCode code =
+          SetError(error, result, "[libpq] Failed to execute COPY statement: %s %s",
+                   PQresStatus(pg_status), PQerrorMessage(conn));
+      PQclear(result);
+      return code;
+    }
+
+    PQclear(result);
+    return ADBC_STATUS_OK;
+  }
+};
+}  // namespace
+
+int TupleReader::GetSchema(struct ArrowSchema* out) {
+  assert(copy_reader_ != nullptr);
+
+  int na_res = copy_reader_->GetSchema(out);
+  if (out->release == nullptr) {
+    SetError(&error_, "[libpq] Result set was already consumed or freed");
+    status_ = ADBC_STATUS_INVALID_STATE;
+    return AdbcStatusCodeToErrno(status_);
+  } else if (na_res != NANOARROW_OK) {
+    // e.g., Can't allocate memory
+    SetError(&error_, "[libpq] Error copying schema");
+    status_ = ADBC_STATUS_INTERNAL;
+  }
+
+  return na_res;
+}
+
+int TupleReader::InitQueryAndFetchFirst(struct ArrowError* error) {
+  // Fetch + parse the header
+  int get_copy_res = PQgetCopyData(conn_, &pgbuf_, /*async=*/0);
+  data_.size_bytes = get_copy_res;
+  data_.data.as_char = pgbuf_;
+
+  if (get_copy_res == -2) {
+    SetError(&error_, "[libpq] Fetch header failed: %s", PQerrorMessage(conn_));
+    status_ = ADBC_STATUS_IO;
+    return AdbcStatusCodeToErrno(status_);
+  }
+
+  int na_res = copy_reader_->ReadHeader(&data_, error);
+  if (na_res != NANOARROW_OK) {
+    SetError(&error_, "[libpq] ReadHeader failed: %s", error->message);
+    status_ = ADBC_STATUS_IO;
+    return AdbcStatusCodeToErrno(status_);
+  }
+
+  return NANOARROW_OK;
+}
+
+int TupleReader::AppendRowAndFetchNext(struct ArrowError* error) {
+  // Parse the result (the header AND the first row are included in the first
+  // call to PQgetCopyData())
+  int na_res = copy_reader_->ReadRecord(&data_, error);
+  if (na_res != NANOARROW_OK && na_res != ENODATA) {
+    SetError(&error_, "[libpq] ReadRecord failed at row %" PRId64 ": %s", row_id_,
+             error->message);
+    status_ = ADBC_STATUS_IO;
+    return na_res;
+  }
+
+  row_id_++;
+
+  // Fetch + check
+  PQfreemem(pgbuf_);
+  pgbuf_ = nullptr;
+  int get_copy_res = PQgetCopyData(conn_, &pgbuf_, /*async=*/0);
+  data_.size_bytes = get_copy_res;
+  data_.data.as_char = pgbuf_;
+
+  if (get_copy_res == -2) {
+    SetError(&error_, "[libpq] PQgetCopyData failed at row %" PRId64 ": %s", row_id_,
+             PQerrorMessage(conn_));
+    status_ = ADBC_STATUS_IO;
+    return AdbcStatusCodeToErrno(status_);
+  } else if (get_copy_res == -1) {
+    // Returned when COPY has finished successfully
+    return ENODATA;
+  } else if ((copy_reader_->array_size_approx_bytes() + get_copy_res) >=
+             batch_size_hint_bytes_) {
+    // Appending the next row will result in an array larger than requested.
+    // Return EOVERFLOW to force GetNext() to build the current result and return.
+    return EOVERFLOW;
+  } else {
+    return NANOARROW_OK;
+  }
+}
+
+int TupleReader::BuildOutput(struct ArrowArray* out, struct ArrowError* error) {
+  if (copy_reader_->array_size_approx_bytes() == 0) {
+    out->release = nullptr;
+    return NANOARROW_OK;
+  }
+
+  int na_res = copy_reader_->GetArray(out, error);
+  if (na_res != NANOARROW_OK) {
+    SetError(&error_, "[libpq] Failed to build result array: %s", error->message);
+    status_ = ADBC_STATUS_INTERNAL;
+    return na_res;
+  }
+
+  return NANOARROW_OK;
+}
+
+int TupleReader::GetNext(struct ArrowArray* out) {
+  if (is_finished_) {
+    out->release = nullptr;
+    return 0;
+  }
+
+  struct ArrowError error;
+  error.message[0] = '\0';
+
+  if (row_id_ == -1) {
+    NANOARROW_RETURN_NOT_OK(InitQueryAndFetchFirst(&error));
+    row_id_++;
+  }
+
+  int na_res;
+  do {
+    na_res = AppendRowAndFetchNext(&error);
+    if (na_res == EOVERFLOW) {
+      // The result would be too big to return if we appended the row. When EOVERFLOW is
+      // returned, the copy reader leaves the output in a valid state. The data is left in
+      // pg_buf_/data_ and will attempt to be appended on the next call to GetNext()
+      return BuildOutput(out, &error);
+    }
+  } while (na_res == NANOARROW_OK);
+
+  if (na_res != ENODATA) {
+    return na_res;
+  }
+
+  is_finished_ = true;
+
+  // Finish the result properly and return the last result. Note that BuildOutput() may
+  // set tmp.release = nullptr if there were zero rows in the copy reader (can
+  // occur in an overflow scenario).
+  struct ArrowArray tmp;
+  NANOARROW_RETURN_NOT_OK(BuildOutput(&tmp, &error));
+
+  PQclear(result_);
+  // Check the server-side response
+  result_ = PQgetResult(conn_);
+  const ExecStatusType pq_status = PQresultStatus(result_);
+  if (pq_status != PGRES_COMMAND_OK) {
+    const char* sqlstate = PQresultErrorField(result_, PG_DIAG_SQLSTATE);
+    SetError(&error_, result_, "[libpq] Query failed [%s]: %s", PQresStatus(pq_status),
+             PQresultErrorMessage(result_));
+
+    if (tmp.release != nullptr) {
+      tmp.release(&tmp);
+    }
+
+    if (sqlstate != nullptr && std::strcmp(sqlstate, "57014") == 0) {
+      status_ = ADBC_STATUS_CANCELLED;
+    } else {
+      status_ = ADBC_STATUS_IO;
+    }
+    return AdbcStatusCodeToErrno(status_);
+  }
+
+  ArrowArrayMove(&tmp, out);
+  return NANOARROW_OK;
+}
+
+void TupleReader::Release() {
+  if (error_.release) {
+    error_.release(&error_);
+  }
+  error_ = ADBC_ERROR_INIT;
+  status_ = ADBC_STATUS_OK;
+
+  if (result_) {
+    PQclear(result_);
+    result_ = nullptr;
+  }
+
+  if (pgbuf_) {
+    PQfreemem(pgbuf_);
+    pgbuf_ = nullptr;
+  }
+
+  if (copy_reader_) {
+    copy_reader_.reset();
+  }
+
+  is_finished_ = false;
+  row_id_ = -1;
+}
+
+void TupleReader::ExportTo(struct ArrowArrayStream* stream) {
+  stream->get_schema = &GetSchemaTrampoline;
+  stream->get_next = &GetNextTrampoline;
+  stream->get_last_error = &GetLastErrorTrampoline;
+  stream->release = &ReleaseTrampoline;
+  stream->private_data = this;
+}
+
+const struct AdbcError* TupleReader::ErrorFromArrayStream(struct ArrowArrayStream* stream,
+                                                          AdbcStatusCode* status) {
+  if (!stream->private_data || stream->release != &ReleaseTrampoline) {
+    return nullptr;
+  }
+
+  TupleReader* reader = static_cast<TupleReader*>(stream->private_data);
+  if (status) {
+    *status = reader->status_;
+  }
+  return &reader->error_;
+}
+
+int TupleReader::GetSchemaTrampoline(struct ArrowArrayStream* self,
+                                     struct ArrowSchema* out) {
+  if (!self || !self->private_data) return EINVAL;
+
+  TupleReader* reader = static_cast<TupleReader*>(self->private_data);
+  return reader->GetSchema(out);
+}
+
+int TupleReader::GetNextTrampoline(struct ArrowArrayStream* self,
+                                   struct ArrowArray* out) {
+  if (!self || !self->private_data) return EINVAL;
+
+  TupleReader* reader = static_cast<TupleReader*>(self->private_data);
+  return reader->GetNext(out);
+}
+
+const char* TupleReader::GetLastErrorTrampoline(struct ArrowArrayStream* self) {
+  if (!self || !self->private_data) return nullptr;
+
+  TupleReader* reader = static_cast<TupleReader*>(self->private_data);
+  return reader->last_error();
+}
+
+void TupleReader::ReleaseTrampoline(struct ArrowArrayStream* self) {
+  if (!self || !self->private_data) return;
+
+  TupleReader* reader = static_cast<TupleReader*>(self->private_data);
+  reader->Release();
+  self->private_data = nullptr;
+  self->release = nullptr;
+}
+
+AdbcStatusCode PostgresStatement::New(struct AdbcConnection* connection,
+                                      struct AdbcError* error) {
+  if (!connection || !connection->private_data) {
+    SetError(error, "%s", "[libpq] Must provide an initialized AdbcConnection");
+    return ADBC_STATUS_INVALID_ARGUMENT;
+  }
+  connection_ =
+      *reinterpret_cast<std::shared_ptr<PostgresConnection>*>(connection->private_data);
+  type_resolver_ = connection_->type_resolver();
+  reader_.conn_ = connection_->conn();
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresStatement::Bind(struct ArrowArray* values,
+                                       struct ArrowSchema* schema,
+                                       struct AdbcError* error) {
+  if (!values || !values->release) {
+    SetError(error, "%s", "[libpq] Must provide non-NULL array");
+    return ADBC_STATUS_INVALID_ARGUMENT;
+  } else if (!schema || !schema->release) {
+    SetError(error, "%s", "[libpq] Must provide non-NULL schema");
+    return ADBC_STATUS_INVALID_ARGUMENT;
+  }
+
+  if (bind_.release) bind_.release(&bind_);
+  // Make a one-value stream
+  bind_.private_data = new OneValueStream{*schema, *values};
+  bind_.get_schema = &OneValueStream::GetSchema;
+  bind_.get_next = &OneValueStream::GetNext;
+  bind_.get_last_error = &OneValueStream::GetLastError;
+  bind_.release = &OneValueStream::Release;
+  std::memset(values, 0, sizeof(*values));
+  std::memset(schema, 0, sizeof(*schema));
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresStatement::Bind(struct ArrowArrayStream* stream,
+                                       struct AdbcError* error) {
+  if (!stream || !stream->release) {
+    SetError(error, "%s", "[libpq] Must provide non-NULL stream");
+    return ADBC_STATUS_INVALID_ARGUMENT;
+  }
+  // Move stream
+  if (bind_.release) bind_.release(&bind_);
+  bind_ = *stream;
+  std::memset(stream, 0, sizeof(*stream));
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresStatement::Cancel(struct AdbcError* error) {
+  // Ultimately the same underlying PGconn
+  return connection_->Cancel(error);
+}
+
+AdbcStatusCode PostgresStatement::CreateBulkTable(
+    const std::string& current_schema, const struct ArrowSchema& source_schema,
+    const std::vector<struct ArrowSchemaView>& source_schema_fields,
+    std::string* escaped_table, std::string* escaped_field_list,
+    struct AdbcError* error) {
+  PGconn* conn = connection_->conn();
+
+  if (!ingest_.db_schema.empty() && ingest_.temporary) {
+    SetError(error, "[libpq] Cannot set both %s and %s",
+             ADBC_INGEST_OPTION_TARGET_DB_SCHEMA, ADBC_INGEST_OPTION_TEMPORARY);
+    return ADBC_STATUS_INVALID_STATE;
+  }
+
+  {
+    if (!ingest_.db_schema.empty()) {
+      char* escaped =
+          PQescapeIdentifier(conn, ingest_.db_schema.c_str(), ingest_.db_schema.size());
+      if (escaped == nullptr) {
+        SetError(error, "[libpq] Failed to escape target schema %s for ingestion: %s",
+                 ingest_.db_schema.c_str(), PQerrorMessage(conn));
+        return ADBC_STATUS_INTERNAL;
+      }
+      *escaped_table += escaped;
+      *escaped_table += " . ";
+      PQfreemem(escaped);
+    } else if (ingest_.temporary) {
+      // OK to be redundant (CREATE TEMPORARY TABLE pg_temp.foo)
+      *escaped_table += "pg_temp . ";
+    } else {
+      // Explicitly specify the current schema to avoid any temporary tables
+      // shadowing this table
+      char* escaped =
+          PQescapeIdentifier(conn, current_schema.c_str(), current_schema.size());
+      *escaped_table += escaped;
+      *escaped_table += " . ";
+      PQfreemem(escaped);
+    }
+
+    if (!ingest_.target.empty()) {
+      char* escaped =
+          PQescapeIdentifier(conn, ingest_.target.c_str(), ingest_.target.size());
+      if (escaped == nullptr) {
+        SetError(error, "[libpq] Failed to escape target table %s for ingestion: %s",
+                 ingest_.target.c_str(), PQerrorMessage(conn));
+        return ADBC_STATUS_INTERNAL;
+      }
+      *escaped_table += escaped;
+      PQfreemem(escaped);
+    }
+  }
+
+  std::string create;
+
+  if (ingest_.temporary) {
+    create = "CREATE TEMPORARY TABLE ";
+  } else {
+    create = "CREATE TABLE ";
+  }
+
+  switch (ingest_.mode) {
+    case IngestMode::kCreate:
+    case IngestMode::kAppend:
+      // Nothing to do
+      break;
+    case IngestMode::kReplace: {
+      std::string drop = "DROP TABLE IF EXISTS " + *escaped_table;
+      PGresult* result = PQexecParams(conn, drop.c_str(), /*nParams=*/0,
+                                      /*paramTypes=*/nullptr, /*paramValues=*/nullptr,
+                                      /*paramLengths=*/nullptr, /*paramFormats=*/nullptr,
+                                      /*resultFormat=*/1 /*(binary)*/);
+      if (PQresultStatus(result) != PGRES_COMMAND_OK) {
+        AdbcStatusCode code =
+            SetError(error, result, "[libpq] Failed to drop table: %s\nQuery was: %s",
+                     PQerrorMessage(conn), drop.c_str());
+        PQclear(result);
+        return code;
+      }
+      PQclear(result);
+      break;
+    }
+    case IngestMode::kCreateAppend:
+      create += "IF NOT EXISTS ";
+      break;
+  }
+  create += *escaped_table;
+  create += " (";
+
+  for (size_t i = 0; i < source_schema_fields.size(); i++) {
+    if (i > 0) {
+      create += ", ";
+      *escaped_field_list += ", ";
+    }
+
+    const char* unescaped = source_schema.children[i]->name;
+    char* escaped = PQescapeIdentifier(conn, unescaped, std::strlen(unescaped));
+    if (escaped == nullptr) {
+      SetError(error, "[libpq] Failed to escape column %s for ingestion: %s", unescaped,
+               PQerrorMessage(conn));
+      return ADBC_STATUS_INTERNAL;
+    }
+    create += escaped;
+    *escaped_field_list += escaped;
+    PQfreemem(escaped);
+
+    switch (source_schema_fields[i].type) {
+      case ArrowType::NANOARROW_TYPE_BOOL:
+        create += " BOOLEAN";
+        break;
+      case ArrowType::NANOARROW_TYPE_INT8:
+      case ArrowType::NANOARROW_TYPE_INT16:
+        create += " SMALLINT";
+        break;
+      case ArrowType::NANOARROW_TYPE_INT32:
+        create += " INTEGER";
+        break;
+      case ArrowType::NANOARROW_TYPE_INT64:
+        create += " BIGINT";
+        break;
+      case ArrowType::NANOARROW_TYPE_FLOAT:
+        create += " REAL";
+        break;
+      case ArrowType::NANOARROW_TYPE_DOUBLE:
+        create += " DOUBLE PRECISION";
+        break;
+      case ArrowType::NANOARROW_TYPE_STRING:
+      case ArrowType::NANOARROW_TYPE_LARGE_STRING:
+        create += " TEXT";
+        break;
+      case ArrowType::NANOARROW_TYPE_BINARY:
+        create += " BYTEA";
+        break;
+      case ArrowType::NANOARROW_TYPE_DATE32:
+        create += " DATE";
+        break;
+      case ArrowType::NANOARROW_TYPE_TIMESTAMP:
+        if (strcmp("", source_schema_fields[i].timezone)) {
+          create += " TIMESTAMPTZ";
+        } else {
+          create += " TIMESTAMP";
+        }
+        break;
+      case ArrowType::NANOARROW_TYPE_DURATION:
+      case ArrowType::NANOARROW_TYPE_INTERVAL_MONTH_DAY_NANO:
+        create += " INTERVAL";
+        break;
+      case ArrowType::NANOARROW_TYPE_DICTIONARY: {
+        struct ArrowSchemaView value_view;
+        CHECK_NA(INTERNAL,
+                 ArrowSchemaViewInit(&value_view, source_schema.children[i]->dictionary,
+                                     nullptr),
+                 error);
+        switch (value_view.type) {
+          case NANOARROW_TYPE_BINARY:
+          case NANOARROW_TYPE_LARGE_BINARY:
+            create += " BYTEA";
+            break;
+          case NANOARROW_TYPE_STRING:
+          case NANOARROW_TYPE_LARGE_STRING:
+            create += " TEXT";
+            break;
+          default:
+            SetError(error, "%s%" PRIu64 "%s%s%s%s", "[libpq] Field #",
+                     static_cast<uint64_t>(i + 1), " ('", source_schema.children[i]->name,
+                     "') has unsupported dictionary value type for ingestion ",
+                     ArrowTypeString(value_view.type));
+            return ADBC_STATUS_NOT_IMPLEMENTED;
+        }
+        break;
+      }
+      default:
+        SetError(error, "%s%" PRIu64 "%s%s%s%s", "[libpq] Field #",
+                 static_cast<uint64_t>(i + 1), " ('", source_schema.children[i]->name,
+                 "') has unsupported type for ingestion ",
+                 ArrowTypeString(source_schema_fields[i].type));
+        return ADBC_STATUS_NOT_IMPLEMENTED;
+    }
+  }
+
+  if (ingest_.mode == IngestMode::kAppend) {
+    return ADBC_STATUS_OK;
+  }
+
+  create += ")";
+  SetError(error, "%s%s", "[libpq] ", create.c_str());
+  PGresult* result = PQexecParams(conn, create.c_str(), /*nParams=*/0,
+                                  /*paramTypes=*/nullptr, /*paramValues=*/nullptr,
+                                  /*paramLengths=*/nullptr, /*paramFormats=*/nullptr,
+                                  /*resultFormat=*/1 /*(binary)*/);
+  if (PQresultStatus(result) != PGRES_COMMAND_OK) {
+    AdbcStatusCode code =
+        SetError(error, result, "[libpq] Failed to create table: %s\nQuery was: %s",
+                 PQerrorMessage(conn), create.c_str());
+    PQclear(result);
+    return code;
+  }
+  PQclear(result);
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresStatement::ExecutePreparedStatement(
+    struct ArrowArrayStream* stream, int64_t* rows_affected, struct AdbcError* error) {
+  if (!bind_.release) {
+    // TODO: set an empty stream just to unify the code paths
+    SetError(error, "%s",
+             "[libpq] Prepared statements without parameters are not implemented");
+    return ADBC_STATUS_NOT_IMPLEMENTED;
+  }
+  if (stream) {
+    // TODO:
+    SetError(error, "%s",
+             "[libpq] Prepared statements returning result sets are not implemented");
+    return ADBC_STATUS_NOT_IMPLEMENTED;
+  }
+
+  BindStream bind_stream(std::move(bind_));
+  std::memset(&bind_, 0, sizeof(bind_));
+
+  RAISE_ADBC(bind_stream.Begin([&]() { return ADBC_STATUS_OK; }, error));
+  RAISE_ADBC(bind_stream.SetParamTypes(*type_resolver_, error));
+  RAISE_ADBC(
+      bind_stream.Prepare(connection_->conn(), query_, error, connection_->autocommit()));
+  RAISE_ADBC(bind_stream.Execute(connection_->conn(), rows_affected, error));
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresStatement::ExecuteQuery(struct ArrowArrayStream* stream,
+                                               int64_t* rows_affected,
+                                               struct AdbcError* error) {
+  ClearResult();
+  if (prepared_) {
+    if (bind_.release || !stream) {
+      return ExecutePreparedStatement(stream, rows_affected, error);
+    }
+    // XXX: don't use a prepared statement to execute a no-parameter
+    // result-set-returning query for now, since we can't easily get
+    // access to COPY there. (This might have to become sequential
+    // executions of COPY (EXECUTE ($n, ...)) TO STDOUT which won't
+    // get all the benefits of a prepared statement.) At preparation
+    // time we don't know whether the query will be used with a result
+    // set or not without analyzing the query (we could prepare both?)
+    // and https://stackoverflow.com/questions/69233792 suggests that
+    // you can't PREPARE a query containing COPY.
+  }
+  if (!stream && !ingest_.target.empty()) {
+    return ExecuteUpdateBulk(rows_affected, error);
+  }
+
+  // Remove trailing semicolon(s) from the query before feeding it into COPY
+  while (!query_.empty() && query_.back() == ';') {
+    query_.pop_back();
+  }
+
+  if (query_.empty()) {
+    SetError(error, "%s", "[libpq] Must SetSqlQuery before ExecuteQuery");
+    return ADBC_STATUS_INVALID_STATE;
+  }
+
+  // 1. Prepare the query to get the schema
+  {
+    RAISE_ADBC(SetupReader(error));
+
+    // If the caller did not request a result set or if there are no
+    // inferred output columns (e.g. a CREATE or UPDATE), then don't
+    // use COPY (which would fail anyways)
+    if (!stream || reader_.copy_reader_->pg_type().n_children() == 0) {
+      RAISE_ADBC(ExecuteUpdateQuery(rows_affected, error));
+      if (stream) {
+        struct ArrowSchema schema;
+        std::memset(&schema, 0, sizeof(schema));
+        RAISE_NA(reader_.copy_reader_->GetSchema(&schema));
+        nanoarrow::EmptyArrayStream::MakeUnique(&schema).move(stream);
+      }
+      return ADBC_STATUS_OK;
+    }
+
+    // This resolves the reader specific to each PostgresType -> ArrowSchema
+    // conversion. It is unlikely that this will fail given that we have just
+    // inferred these conversions ourselves.
+    struct ArrowError na_error;
+    int na_res = reader_.copy_reader_->InitFieldReaders(&na_error);
+    if (na_res != NANOARROW_OK) {
+      SetError(error, "[libpq] Failed to initialize field readers: %s", na_error.message);
+      return na_res;
+    }
+  }
+
+  // 2. Execute the query with COPY to get binary tuples
+  {
+    std::string copy_query = "COPY (" + query_ + ") TO STDOUT (FORMAT binary)";
+    reader_.result_ =
+        PQexecParams(connection_->conn(), copy_query.c_str(), /*nParams=*/0,
+                     /*paramTypes=*/nullptr, /*paramValues=*/nullptr,
+                     /*paramLengths=*/nullptr, /*paramFormats=*/nullptr, kPgBinaryFormat);
+    if (PQresultStatus(reader_.result_) != PGRES_COPY_OUT) {
+      AdbcStatusCode code = SetError(
+          error, reader_.result_,
+          "[libpq] Failed to execute query: could not begin COPY: %s\nQuery was: %s",
+          PQerrorMessage(connection_->conn()), copy_query.c_str());
+      ClearResult();
+      return code;
+    }
+    // Result is read from the connection, not the result, but we won't clear it here
+  }
+
+  reader_.ExportTo(stream);
+  if (rows_affected) *rows_affected = -1;
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresStatement::ExecuteSchema(struct ArrowSchema* schema,
+                                                struct AdbcError* error) {
+  ClearResult();
+  if (query_.empty()) {
+    SetError(error, "%s", "[libpq] Must SetSqlQuery before ExecuteQuery");
+    return ADBC_STATUS_INVALID_STATE;
+  } else if (bind_.release) {
+    // TODO: if we have parameters, bind them (since they can affect the output schema)
+    SetError(error, "[libpq] ExecuteSchema with parameters is not implemented");
+    return ADBC_STATUS_NOT_IMPLEMENTED;
+  }
+
+  RAISE_ADBC(SetupReader(error));
+  CHECK_NA(INTERNAL, reader_.copy_reader_->GetSchema(schema), error);
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresStatement::ExecuteUpdateBulk(int64_t* rows_affected,
+                                                    struct AdbcError* error) {
+  if (!bind_.release) {
+    SetError(error, "%s", "[libpq] Must Bind() before Execute() for bulk ingestion");
+    return ADBC_STATUS_INVALID_STATE;
+  }
+
+  // Need the current schema to avoid being shadowed by temp tables
+  // This is a little unfortunate; we need another DB roundtrip
+  std::string current_schema;
+  {
+    PqResultHelper result_helper{connection_->conn(), "SELECT CURRENT_SCHEMA", {}, error};
+    RAISE_ADBC(result_helper.Prepare());
+    RAISE_ADBC(result_helper.Execute());
+    auto it = result_helper.begin();
+    if (it == result_helper.end()) {
+      SetError(error, "[libpq] PostgreSQL returned no rows for 'SELECT CURRENT_SCHEMA'");
+      return ADBC_STATUS_INTERNAL;
+    }
+    current_schema = (*it)[0].data;
+  }
+
+  BindStream bind_stream(std::move(bind_));
+  std::memset(&bind_, 0, sizeof(bind_));
+  std::string escaped_table;
+  std::string escaped_field_list;
+  RAISE_ADBC(bind_stream.Begin(
+      [&]() -> AdbcStatusCode {
+        return CreateBulkTable(current_schema, bind_stream.bind_schema.value,
+                               bind_stream.bind_schema_fields, &escaped_table,
+                               &escaped_field_list, error);
+      },
+      error));
+  RAISE_ADBC(bind_stream.SetParamTypes(*type_resolver_, error));
+
+  std::string query = "COPY ";
+  query += escaped_table;
+  query += " (";
+  query += escaped_field_list;
+  query += ") FROM STDIN WITH (FORMAT binary)";
+  PGresult* result = PQexec(connection_->conn(), query.c_str());
+  if (PQresultStatus(result) != PGRES_COPY_IN) {
+    AdbcStatusCode code =
+        SetError(error, result, "[libpq] COPY query failed: %s\nQuery was:%s",
+                 PQerrorMessage(connection_->conn()), query.c_str());
+    PQclear(result);
+    return code;
+  }
+
+  PQclear(result);
+  RAISE_ADBC(bind_stream.ExecuteCopy(connection_->conn(), rows_affected, error));
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresStatement::ExecuteUpdateQuery(int64_t* rows_affected,
+                                                     struct AdbcError* error) {
+  // NOTE: must prepare first (used in ExecuteQuery)
+  PGresult* result =
+      PQexecPrepared(connection_->conn(), /*stmtName=*/"", /*nParams=*/0,
+                     /*paramValues=*/nullptr, /*paramLengths=*/nullptr,
+                     /*paramFormats=*/nullptr, /*resultFormat=*/kPgBinaryFormat);
+  ExecStatusType status = PQresultStatus(result);
+  if (status != PGRES_COMMAND_OK && status != PGRES_TUPLES_OK) {
+    AdbcStatusCode code =
+        SetError(error, result, "[libpq] Failed to execute query: %s\nQuery was:%s",
+                 PQerrorMessage(connection_->conn()), query_.c_str());
+    PQclear(result);
+    return code;
+  }
+  if (rows_affected) {
+    if (status == PGRES_TUPLES_OK) {
+      *rows_affected = PQntuples(reader_.result_);
+    } else {
+      // In theory, PQcmdTuples would work here, but experimentally it gives
+      // an empty string even for a DELETE.  (Also, why does it return a
+      // string...)  Possibly, it doesn't work because we use PQexecPrepared
+      // but the docstring is careful to specify it works on an EXECUTE of a
+      // prepared statement.
+      *rows_affected = -1;
+    }
+  }
+  PQclear(result);
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresStatement::GetOption(const char* key, char* value, size_t* length,
+                                            struct AdbcError* error) {
+  std::string result;
+  if (std::strcmp(key, ADBC_INGEST_OPTION_TARGET_TABLE) == 0) {
+    result = ingest_.target;
+  } else if (std::strcmp(key, ADBC_INGEST_OPTION_TARGET_DB_SCHEMA) == 0) {
+    result = ingest_.db_schema;
+  } else if (std::strcmp(key, ADBC_INGEST_OPTION_MODE) == 0) {
+    switch (ingest_.mode) {
+      case IngestMode::kCreate:
+        result = ADBC_INGEST_OPTION_MODE_CREATE;
+        break;
+      case IngestMode::kAppend:
+        result = ADBC_INGEST_OPTION_MODE_APPEND;
+        break;
+      case IngestMode::kReplace:
+        result = ADBC_INGEST_OPTION_MODE_REPLACE;
+        break;
+      case IngestMode::kCreateAppend:
+        result = ADBC_INGEST_OPTION_MODE_CREATE_APPEND;
+        break;
+    }
+  } else if (std::strcmp(key, ADBC_POSTGRESQL_OPTION_BATCH_SIZE_HINT_BYTES) == 0) {
+    result = std::to_string(reader_.batch_size_hint_bytes_);
+  } else {
+    SetError(error, "[libpq] Unknown statement option '%s'", key);
+    return ADBC_STATUS_NOT_FOUND;
+  }
+
+  if (result.size() + 1 <= *length) {
+    std::memcpy(value, result.data(), result.size() + 1);
+  }
+  *length = static_cast<int64_t>(result.size() + 1);
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresStatement::GetOptionBytes(const char* key, uint8_t* value,
+                                                 size_t* length,
+                                                 struct AdbcError* error) {
+  SetError(error, "[libpq] Unknown statement option '%s'", key);
+  return ADBC_STATUS_NOT_FOUND;
+}
+
+AdbcStatusCode PostgresStatement::GetOptionDouble(const char* key, double* value,
+                                                  struct AdbcError* error) {
+  SetError(error, "[libpq] Unknown statement option '%s'", key);
+  return ADBC_STATUS_NOT_FOUND;
+}
+
+AdbcStatusCode PostgresStatement::GetOptionInt(const char* key, int64_t* value,
+                                               struct AdbcError* error) {
+  std::string result;
+  if (std::strcmp(key, ADBC_POSTGRESQL_OPTION_BATCH_SIZE_HINT_BYTES) == 0) {
+    *value = reader_.batch_size_hint_bytes_;
+    return ADBC_STATUS_OK;
+  }
+  SetError(error, "[libpq] Unknown statement option '%s'", key);
+  return ADBC_STATUS_NOT_FOUND;
+}
+
+AdbcStatusCode PostgresStatement::GetParameterSchema(struct ArrowSchema* schema,
+                                                     struct AdbcError* error) {
+  return ADBC_STATUS_NOT_IMPLEMENTED;
+}
+
+AdbcStatusCode PostgresStatement::Prepare(struct AdbcError* error) {
+  if (query_.empty()) {
+    SetError(error, "%s", "[libpq] Must SetSqlQuery() before Prepare()");
+    return ADBC_STATUS_INVALID_STATE;
+  }
+
+  // Don't actually prepare until execution time, so we know the
+  // parameter types
+  prepared_ = true;
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresStatement::Release(struct AdbcError* error) {
+  ClearResult();
+  if (bind_.release) {
+    bind_.release(&bind_);
+  }
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresStatement::SetSqlQuery(const char* query,
+                                              struct AdbcError* error) {
+  ingest_.target.clear();
+  ingest_.db_schema.clear();
+  query_ = query;
+  prepared_ = false;
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresStatement::SetOption(const char* key, const char* value,
+                                            struct AdbcError* error) {
+  if (std::strcmp(key, ADBC_INGEST_OPTION_TARGET_TABLE) == 0) {
+    query_.clear();
+    ingest_.target = value;
+    prepared_ = false;
+  } else if (std::strcmp(key, ADBC_INGEST_OPTION_TARGET_DB_SCHEMA) == 0) {
+    query_.clear();
+    if (value == nullptr) {
+      ingest_.db_schema.clear();
+    } else {
+      ingest_.db_schema = value;
+    }
+    prepared_ = false;
+  } else if (std::strcmp(key, ADBC_INGEST_OPTION_MODE) == 0) {
+    if (std::strcmp(value, ADBC_INGEST_OPTION_MODE_CREATE) == 0) {
+      ingest_.mode = IngestMode::kCreate;
+    } else if (std::strcmp(value, ADBC_INGEST_OPTION_MODE_APPEND) == 0) {
+      ingest_.mode = IngestMode::kAppend;
+    } else if (std::strcmp(value, ADBC_INGEST_OPTION_MODE_REPLACE) == 0) {
+      ingest_.mode = IngestMode::kReplace;
+    } else if (std::strcmp(value, ADBC_INGEST_OPTION_MODE_CREATE_APPEND) == 0) {
+      ingest_.mode = IngestMode::kCreateAppend;
+    } else {
+      SetError(error, "[libpq] Invalid value '%s' for option '%s'", value, key);
+      return ADBC_STATUS_INVALID_ARGUMENT;
+    }
+    prepared_ = false;
+  } else if (std::strcmp(key, ADBC_INGEST_OPTION_TEMPORARY) == 0) {
+    if (std::strcmp(value, ADBC_OPTION_VALUE_ENABLED) == 0) {
+      // https://github.com/apache/arrow-adbc/issues/1109: only clear the
+      // schema if enabling since Python always sets the flag explicitly
+      ingest_.temporary = true;
+      ingest_.db_schema.clear();
+    } else if (std::strcmp(value, ADBC_OPTION_VALUE_DISABLED) == 0) {
+      ingest_.temporary = false;
+    } else {
+      SetError(error, "[libpq] Invalid value '%s' for option '%s'", value, key);
+      return ADBC_STATUS_INVALID_ARGUMENT;
+    }
+    prepared_ = false;
+  } else if (std::strcmp(key, ADBC_POSTGRESQL_OPTION_BATCH_SIZE_HINT_BYTES) == 0) {
+    int64_t int_value = std::atol(value);
+    if (int_value <= 0) {
+      SetError(error, "[libpq] Invalid value '%s' for option '%s'", value, key);
+      return ADBC_STATUS_INVALID_ARGUMENT;
+    }
+
+    this->reader_.batch_size_hint_bytes_ = int_value;
+  } else {
+    SetError(error, "[libpq] Unknown statement option '%s'", key);
+    return ADBC_STATUS_NOT_IMPLEMENTED;
+  }
+  return ADBC_STATUS_OK;
+}
+
+AdbcStatusCode PostgresStatement::SetOptionBytes(const char* key, const uint8_t* value,
+                                                 size_t length, struct AdbcError* error) {
+  SetError(error, "%s%s", "[libpq] Unknown statement option ", key);
+  return ADBC_STATUS_NOT_IMPLEMENTED;
+}
+
+AdbcStatusCode PostgresStatement::SetOptionDouble(const char* key, double value,
+                                                  struct AdbcError* error) {
+  SetError(error, "%s%s", "[libpq] Unknown statement option ", key);
+  return ADBC_STATUS_NOT_IMPLEMENTED;
+}
+
+AdbcStatusCode PostgresStatement::SetOptionInt(const char* key, int64_t value,
+                                               struct AdbcError* error) {
+  if (std::strcmp(key, ADBC_POSTGRESQL_OPTION_BATCH_SIZE_HINT_BYTES) == 0) {
+    if (value <= 0) {
+      SetError(error, "[libpq] Invalid value '%" PRIi64 "' for option '%s'", value, key);
+      return ADBC_STATUS_INVALID_ARGUMENT;
+    }
+
+    this->reader_.batch_size_hint_bytes_ = value;
+    return ADBC_STATUS_OK;
+  }
+  SetError(error, "[libpq] Unknown statement option '%s'", key);
+  return ADBC_STATUS_NOT_IMPLEMENTED;
+}
+
+AdbcStatusCode PostgresStatement::SetupReader(struct AdbcError* error) {
+  // TODO: we should pipeline here and assume this will succeed
+  PGresult* result = PQprepare(connection_->conn(), /*stmtName=*/"", query_.c_str(),
+                               /*nParams=*/0, nullptr);
+  if (PQresultStatus(result) != PGRES_COMMAND_OK) {
+    AdbcStatusCode code =
+        SetError(error, result,
+                 "[libpq] Failed to execute query: could not infer schema: failed to "
+                 "prepare query: %s\nQuery was:%s",
+                 PQerrorMessage(connection_->conn()), query_.c_str());
+    PQclear(result);
+    return code;
+  }
+  PQclear(result);
+  result = PQdescribePrepared(connection_->conn(), /*stmtName=*/"");
+  if (PQresultStatus(result) != PGRES_COMMAND_OK) {
+    AdbcStatusCode code =
+        SetError(error, result,
+                 "[libpq] Failed to execute query: could not infer schema: failed to "
+                 "describe prepared statement: %s\nQuery was:%s",
+                 PQerrorMessage(connection_->conn()), query_.c_str());
+    PQclear(result);
+    return code;
+  }
+
+  // Resolve the information from the PGresult into a PostgresType
+  PostgresType root_type;
+  AdbcStatusCode status = ResolvePostgresType(*type_resolver_, result, &root_type, error);
+  PQclear(result);
+  if (status != ADBC_STATUS_OK) return status;
+
+  // Initialize the copy reader and infer the output schema (i.e., error for
+  // unsupported types before issuing the COPY query)
+  reader_.copy_reader_.reset(new PostgresCopyStreamReader());
+  reader_.copy_reader_->Init(root_type);
+  struct ArrowError na_error;
+  int na_res = reader_.copy_reader_->InferOutputSchema(&na_error);
+  if (na_res != NANOARROW_OK) {
+    SetError(error, "[libpq] Failed to infer output schema: (%d) %s: %s", na_res,
+             std::strerror(na_res), na_error.message);
+    return ADBC_STATUS_INTERNAL;
+  }
+  return ADBC_STATUS_OK;
+}
+
+void PostgresStatement::ClearResult() {
+  // TODO: we may want to synchronize here for safety
+  reader_.Release();
+}
+}  // namespace adbcpq

--- a/c/driver/netezza/statement.h
+++ b/c/driver/netezza/statement.h
@@ -1,0 +1,166 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <adbc.h>
+#include <libpq-fe.h>
+#include <nanoarrow/nanoarrow.h>
+
+#include "common/utils.h"
+#include "postgres_copy_reader.h"
+#include "postgres_type.h"
+
+#define ADBC_POSTGRESQL_OPTION_BATCH_SIZE_HINT_BYTES \
+  "adbc.postgresql.batch_size_hint_bytes"
+
+namespace adbcpq {
+class PostgresConnection;
+class PostgresStatement;
+
+/// \brief An ArrowArrayStream that reads tuples from a PGresult.
+class TupleReader final {
+ public:
+  TupleReader(PGconn* conn)
+      : status_(ADBC_STATUS_OK),
+        error_(ADBC_ERROR_INIT),
+        conn_(conn),
+        result_(nullptr),
+        pgbuf_(nullptr),
+        copy_reader_(nullptr),
+        row_id_(-1),
+        batch_size_hint_bytes_(16777216),
+        is_finished_(false) {
+    data_.data.as_char = nullptr;
+    data_.size_bytes = 0;
+  }
+
+  int GetSchema(struct ArrowSchema* out);
+  int GetNext(struct ArrowArray* out);
+  const char* last_error() const { return error_.message; }
+  void Release();
+  void ExportTo(struct ArrowArrayStream* stream);
+
+  static const struct AdbcError* ErrorFromArrayStream(struct ArrowArrayStream* stream,
+                                                      AdbcStatusCode* status);
+
+ private:
+  friend class PostgresStatement;
+
+  int InitQueryAndFetchFirst(struct ArrowError* error);
+  int AppendRowAndFetchNext(struct ArrowError* error);
+  int BuildOutput(struct ArrowArray* out, struct ArrowError* error);
+
+  static int GetSchemaTrampoline(struct ArrowArrayStream* self, struct ArrowSchema* out);
+  static int GetNextTrampoline(struct ArrowArrayStream* self, struct ArrowArray* out);
+  static const char* GetLastErrorTrampoline(struct ArrowArrayStream* self);
+  static void ReleaseTrampoline(struct ArrowArrayStream* self);
+
+  AdbcStatusCode status_;
+  struct AdbcError error_;
+  PGconn* conn_;
+  PGresult* result_;
+  char* pgbuf_;
+  struct ArrowBufferView data_;
+  std::unique_ptr<PostgresCopyStreamReader> copy_reader_;
+  int64_t row_id_;
+  int64_t batch_size_hint_bytes_;
+  bool is_finished_;
+};
+
+class PostgresStatement {
+ public:
+  PostgresStatement()
+      : connection_(nullptr), query_(), prepared_(false), reader_(nullptr) {
+    std::memset(&bind_, 0, sizeof(bind_));
+  }
+
+  // ---------------------------------------------------------------------
+  // ADBC API implementation
+
+  AdbcStatusCode Bind(struct ArrowArray* values, struct ArrowSchema* schema,
+                      struct AdbcError* error);
+  AdbcStatusCode Bind(struct ArrowArrayStream* stream, struct AdbcError* error);
+  AdbcStatusCode Cancel(struct AdbcError* error);
+  AdbcStatusCode ExecuteQuery(struct ArrowArrayStream* stream, int64_t* rows_affected,
+                              struct AdbcError* error);
+  AdbcStatusCode ExecuteSchema(struct ArrowSchema* schema, struct AdbcError* error);
+  AdbcStatusCode GetOption(const char* key, char* value, size_t* length,
+                           struct AdbcError* error);
+  AdbcStatusCode GetOptionBytes(const char* key, uint8_t* value, size_t* length,
+                                struct AdbcError* error);
+  AdbcStatusCode GetOptionDouble(const char* key, double* value, struct AdbcError* error);
+  AdbcStatusCode GetOptionInt(const char* key, int64_t* value, struct AdbcError* error);
+  AdbcStatusCode GetParameterSchema(struct ArrowSchema* schema, struct AdbcError* error);
+  AdbcStatusCode New(struct AdbcConnection* connection, struct AdbcError* error);
+  AdbcStatusCode Prepare(struct AdbcError* error);
+  AdbcStatusCode Release(struct AdbcError* error);
+  AdbcStatusCode SetOption(const char* key, const char* value, struct AdbcError* error);
+  AdbcStatusCode SetOptionBytes(const char* key, const uint8_t* value, size_t length,
+                                struct AdbcError* error);
+  AdbcStatusCode SetOptionDouble(const char* key, double value, struct AdbcError* error);
+  AdbcStatusCode SetOptionInt(const char* key, int64_t value, struct AdbcError* error);
+  AdbcStatusCode SetSqlQuery(const char* query, struct AdbcError* error);
+
+  // ---------------------------------------------------------------------
+  // Helper methods
+
+  void ClearResult();
+  AdbcStatusCode CreateBulkTable(
+      const std::string& current_schema, const struct ArrowSchema& source_schema,
+      const std::vector<struct ArrowSchemaView>& source_schema_fields,
+      std::string* escaped_table, std::string* escaped_field_list,
+      struct AdbcError* error);
+  AdbcStatusCode ExecuteUpdateBulk(int64_t* rows_affected, struct AdbcError* error);
+  AdbcStatusCode ExecuteUpdateQuery(int64_t* rows_affected, struct AdbcError* error);
+  AdbcStatusCode ExecutePreparedStatement(struct ArrowArrayStream* stream,
+                                          int64_t* rows_affected,
+                                          struct AdbcError* error);
+  AdbcStatusCode SetupReader(struct AdbcError* error);
+
+ private:
+  std::shared_ptr<PostgresTypeResolver> type_resolver_;
+  std::shared_ptr<PostgresConnection> connection_;
+
+  // Query state
+  std::string query_;
+  bool prepared_;
+  struct ArrowArrayStream bind_;
+
+  // Bulk ingest state
+  enum class IngestMode {
+    kCreate,
+    kAppend,
+    kReplace,
+    kCreateAppend,
+  };
+
+  struct {
+    std::string db_schema;
+    std::string target;
+    IngestMode mode = IngestMode::kCreate;
+    bool temporary = false;
+  } ingest_;
+
+  TupleReader reader_;
+};
+}  // namespace adbcpq

--- a/c/driver/netezza/vcpkg.json
+++ b/c/driver/netezza/vcpkg.json
@@ -1,0 +1,7 @@
+{
+    "name": "adbc-driver-postgresql",
+    "version-string": "1.0.0a0",
+    "dependencies": [
+        "libpq"
+    ]
+}


### PR DESCRIPTION
```
[root@pgsandbox1 c]# cmake CMakeLists.txt -DADBC_DRIVER_NETEZZA=ON
-- The C compiler identification is GNU 8.5.0
-- The CXX compiler identification is GNU 8.5.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CXX_LINKER_SUPPORTS_VERSION_SCRIPT
-- Performing Test CXX_LINKER_SUPPORTS_VERSION_SCRIPT - Success
-- Found PkgConfig: /usr/bin/pkg-config (found version "1.4.2")
-- Checking for module 'libpq'
--   Found libpq, version 13.11
-- ---------------------------------------------------------------------
-- ADBC version: 0.9.0-SNAPSHOT
--
-- Build configuration summary:
--   CMake version: 3.28.1
--   Generator: Unix Makefiles
--   Build type:
--   Source directory: /home/repo/work/arrow-adbc/c
--   Install prefix: /usr/local
--
-- Compile and link options:
--
--   ADBC_BUILD_WARNING_LEVEL=CHECKIN [default=""]
--       CHECKIN to enable Werror, PRODUCTION otherwise
--   ADBC_CXXFLAGS="" [default=""]
--       Compiler flags to append when compiling ADBC C++ libraries
--   ADBC_GO_BUILD_TAGS="" [default=""]
--       Build tags to append when compiling ADBC Go libraries
--   ADBC_BUILD_STATIC=ON [default=ON]
--       Build static libraries
--   ADBC_BUILD_SHARED=ON [default=ON]
--       Build shared libraries
--   ADBC_PACKAGE_KIND="" [default=""]
--       Arbitrary string that identifies the kind of package
--       (for informational purposes)
--   ADBC_GIT_ID=4df8ee1ce1bf833add705f8e1bc684d2e62ff1f1 [default=""]
--       The Arrow git commit id (if any)
--   ADBC_GIT_DESCRIPTION="" [default=""]
--       The Arrow git commit description (if any)
--   ADBC_NO_DEPRECATED_API=OFF [default=OFF]
--       Exclude deprecated APIs from build
--   ADBC_USE_CCACHE=ON [default=ON]
--       Use ccache when compiling (if available)
--   ADBC_USE_PRECOMPILED_HEADERS=OFF [default=OFF]
--       Use precompiled headers when compiling
--   ADBC_ARMV8_ARCH=armv8-a [default=armv8-a|armv8-a+crc+crypto]
--       Arm64 arch and extensions
--   ADBC_ALTIVEC=ON [default=ON]
--       Build with Altivec if compiler has support
--   ADBC_RPATH_ORIGIN=OFF [default=OFF]
--       Build Arrow libraries with RATH set to $ORIGIN
--   ADBC_INSTALL_NAME_RPATH=ON [default=ON]
--       Build Arrow libraries with install_name set to @rpath
--   ADBC_GGDB_DEBUG=ON [default=ON]
--       Pass -ggdb flag to debug builds
--
-- Test and benchmark options:
--
--   ADBC_BUILD_EXAMPLES=OFF [default=OFF]
--       Build the Arrow examples
--   ADBC_BUILD_TESTS=OFF [default=OFF]
--       Build the Arrow googletest unit tests
--   ADBC_BUILD_INTEGRATION=OFF [default=OFF]
--       Build the Arrow integration test executables
--   ADBC_BUILD_BENCHMARKS=OFF [default=OFF]
--       Build the Arrow micro benchmarks
--   ADBC_TEST_LINKAGE=shared [default=shared|static]
--       Linkage of Arrow libraries with unit tests executables.
--
-- Lint options:
--
--   ADBC_GENERATE_COVERAGE=OFF [default=OFF]
--       Build with C++ code coverage enabled
--
-- Checks options:
--
--   ADBC_TEST_MEMCHECK=OFF [default=OFF]
--       Run the test suite using valgrind --tool=memcheck
--   ADBC_USE_ASAN=OFF [default=OFF]
--       Enable Address Sanitizer checks
--   ADBC_USE_TSAN=OFF [default=OFF]
--       Enable Thread Sanitizer checks
--   ADBC_USE_UBSAN=OFF [default=OFF]
--       Enable Undefined Behavior sanitizer checks
--
-- Thirdparty toolchain options:
--
--   ADBC_DEPENDENCY_SOURCE=AUTO [default=AUTO|BUNDLED|SYSTEM|CONDA|VCPKG|BREW]
--       Method to use for acquiring arrow's build dependencies
--
-- Advanced developer options:
--
--
-- Project components options:
--
--   ADBC_DRIVER_FLIGHTSQL=OFF [default=OFF]
--       Build the Flight SQL driver
--   ADBC_DRIVER_MANAGER=OFF [default=OFF]
--       Build the driver manager
--   ADBC_DRIVER_POSTGRESQL=OFF [default=OFF]
--       Build the PostgreSQL driver
--   ADBC_DRIVER_NETEZZA=ON [default=OFF]
--       Build the IBM Netezza driver
--   ADBC_DRIVER_SQLITE=OFF [default=OFF]
--       Build the SQLite driver
--   ADBC_DRIVER_SNOWFLAKE=OFF [default=OFF]
--       Build the Snowflake driver
--   ADBC_INTEGRATION_DUCKDB=OFF [default=OFF]
--       Build the test suite for DuckDB
-- Configuring done (1.6s)
-- Generating done (0.0s)
-- Build files have been written to: /home/repo/work/arrow-adbc/c
[root@pgsandbox1 c]# make
[  8%] Building C object vendor/nanoarrow/CMakeFiles/nanoarrow.dir/nanoarrow.c.o
[ 16%] Linking C static library libnanoarrow.a
[ 16%] Built target nanoarrow
[ 25%] Building C object driver/common/CMakeFiles/adbc_driver_common.dir/utils.c.o
[ 33%] Linking C static library libadbc_driver_common.a
[ 33%] Built target adbc_driver_common
[ 41%] Building CXX object driver/netezza/CMakeFiles/adbc_driver_postgresql_objlib.dir/connection.cc.o
[ 50%] Building CXX object driver/netezza/CMakeFiles/adbc_driver_postgresql_objlib.dir/error.cc.o
[ 58%] Building CXX object driver/netezza/CMakeFiles/adbc_driver_postgresql_objlib.dir/database.cc.o
[ 66%] Building CXX object driver/netezza/CMakeFiles/adbc_driver_postgresql_objlib.dir/postgresql.cc.o
[ 75%] Building CXX object driver/netezza/CMakeFiles/adbc_driver_postgresql_objlib.dir/result_helper.cc.o
[ 83%] Building CXX object driver/netezza/CMakeFiles/adbc_driver_postgresql_objlib.dir/statement.cc.o
[ 83%] Built target adbc_driver_postgresql_objlib
[ 91%] Linking CXX shared library libadbc_driver_postgresql.so
[ 91%] Built target adbc_driver_postgresql_shared
[100%] Linking CXX static library libadbc_driver_postgresql.a
[100%] Built target adbc_driver_postgresql_static
[root@pgsandbox1 c]#
```