### PR TITLE
Update postgres_copy_reader.cc

### DIFF
--- a/c/driver/netezza/postgres_copy_reader.cc
+++ b/c/driver/netezza/postgres_copy_reader.cc
@@ -660,6 +660,11 @@ namespace adbcpq {
         case NetezzaTypeId::kText:
         case NetezzaTypeId::kBpchar:
         case NetezzaTypeId::kName:
+        case NetezzaTypeId::kNchar:
+        case NetezzaTypeId::kNchar:
+        case NetezzaTypeId::kJson:
+        case NetezzaTypeId::kJsonb:
+        case NetezzaTypeId::kJsonpath:
           *out = new PostgresCopyBinaryFieldReader();
           return NANOARROW_OK;
         case NetezzaTypeId::kNumeric:


### PR DESCRIPTION
added more datatype support

Not mentioning the datatypes in switch gives segmentation fault.